### PR TITLE
Improve print layouts

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -32,12 +32,12 @@ export function MatchesTab({
     return team?.name || (isSolo ? 'Joueur inconnu' : 'Équipe inconnue');
   };
 
-  const getTeamPlayers = (teamId: string) => {
+  const getTeamPlayers = (teamId: string, separator = ', ') => {
     const team = teams.find(t => t.id === teamId);
     if (!team) return '';
     return team.players
       .map(player => (player.label ? `[${player.label}] ${player.name}` : player.name))
-      .join(', ');
+      .join(separator);
   };
 
   const getGroupLabel = (ids: string[]) => {
@@ -112,12 +112,11 @@ export function MatchesTab({
                 <tr>
                   <td>${match.isBye ? '-' : match.court}</td>
                   <td>
-                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : getTeamName(match.team1Id)}
-                    ${!match.team1Ids ? `<br/><small>${getTeamPlayers(match.team1Id)}</small>` : ''}
+                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : `${getTeamName(match.team1Id)} : ${getTeamPlayers(match.team1Id, ' - ')}`}
                   </td>
                   <td class="score">${match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}</td>
                   <td>
-                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `${getTeamName(match.team2Id)}<br/><small>${getTeamPlayers(match.team2Id)}</small>`}
+                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `${getTeamName(match.team2Id)} : ${getTeamPlayers(match.team2Id, ' - ')}`}
                   </td>
                 </tr>
               `).join('')}

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -56,9 +56,8 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
           <style>
             body { font-family: Arial, sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 20px; }
-            .team { margin-bottom: 20px; padding: 15px; border: 1px solid #ccc; border-radius: 8px; }
-            .team-name { font-weight: bold; font-size: 18px; margin-bottom: 10px; }
-            .player { margin: 5px 0; padding: 8px; background: #f5f5f5; border-radius: 4px; }
+            .team { margin-bottom: 10px; padding: 10px; border: 1px solid #ccc; border-radius: 8px; }
+            .team-name { font-weight: bold; font-size: 18px; }
             @media print { body { margin: 0; } }
           </style>
         </head>
@@ -68,16 +67,9 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
             .map(
               (team) => `
             <div class="team">
-              <div class="team-name">${team.name}</div>
-              ${team.players
-                .map(
-                  (player) => `
-                <div class="player">
-                  ${player.name} ${player.label ? `[${player.label}]` : ''}
-                </div>
-              `
-                )
-                .join('')}
+              <div class="team-name">${team.name} : ${team.players
+                .map(player => `${player.name}${player.label ? ` [${player.label}]` : ''}`)
+                .join(' - ')}</div>
             </div>
           `
             )


### PR DESCRIPTION
## Summary
- show players separated by hyphen when printing matches
- compact team print layout with single line per team

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860381ba5f4832488309d71b9cc6ac1