### PR TITLE
Améliore affichage joueurs et impression des matchs

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -89,7 +89,7 @@ export function MatchesTab({
             body { font-family: Arial, sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 20px; }
             table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-            th, td { padding: 12px; text-align: left; border: 1px solid #ddd; }
+            th, td { padding: 12px; text-align: center; border: 1px solid #ddd; }
             th { background-color: #f2f2f2; font-weight: bold; }
             tr:nth-child(even) { background-color: #f9f9f9; }
             .score { font-size: 18px; font-weight: bold; text-align: center; }

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -142,20 +142,18 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
               </button>
             </div>
 
-            <div className="space-y-3">
-              {team.players.map((player: Player) => (
-                <div key={player.id} className="glass-card p-4">
-                  <div className="flex items-center space-x-3">
-                    {player.label && (
-                      <span className="w-8 h-8 bg-blue-400/20 border border-blue-400 text-blue-400 rounded-full flex items-center justify-center text-sm font-bold">
-                        {player.label}
-                      </span>
-                    )}
-                    <span className="font-bold text-white text-lg">{player.name}</span>
-                  </div>
+              <div className="space-y-3">
+                <div className="glass-card p-4">
+                  <p className="text-white font-medium">
+                    {team.players
+                      .map(
+                        (player: Player) =>
+                          `${player.name}${player.label ? ` [${player.label}]` : ''}`
+                      )
+                      .join(' - ')}
+                  </p>
                 </div>
-              ))}
-            </div>
+              </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show player names inline in the team list
- center every column in the printed match list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68604ae209648324a3c77ed9585ffda4