### PR TITLE
Compact standings rows

### DIFF
--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -145,39 +145,35 @@ export function StandingsTab({ teams }: StandingsTabProps) {
                 <tr key={team.id} className={`hover:bg-white/5 transition-colors ${
                   index < 3 ? 'bg-gradient-to-r from-yellow-400/10 to-transparent' : ''
                 }`}>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <div className="flex items-center justify-center">
                       {getPositionIcon(index)}
                     </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="font-bold text-white text-lg">{team.name}</div>
-                    <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2">
-                      {team.players.map((player) => (
-                        <div key={player.id} className="flex items-center space-x-2 text-sm text-white/80 font-medium">
-                          {player.label && (
-                            <span className="w-5 h-5 bg-blue-400/20 border border-blue-400 text-blue-400 rounded-full flex items-center justify-center text-xs font-bold">
-                              {player.label}
-                            </span>
-                          )}
-                          <span>{player.name}</span>
-                        </div>
-                      ))}
-                    </div>
+                  <td className="px-6 py-2 whitespace-nowrap">
+                    <span className="font-bold text-white text-lg">
+                      {team.name}
+                      {team.players.length > 0 && ' - '}
+                      {team.players
+                        .map((player) =>
+                          `${player.label ? `[${player.label}] ` : ''}${player.name}`
+                        )
+                        .join(', ')}
+                    </span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <span className="text-2xl font-bold text-green-400">{team.wins}</span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <span className="text-2xl font-bold text-red-400">{team.losses}</span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <span className="text-lg font-bold text-white">{team.pointsFor}</span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <span className="text-lg font-bold text-white">{team.pointsAgainst}</span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                  <td className="px-6 py-2 whitespace-nowrap text-center">
                     <div className="flex items-center justify-center space-x-2">
                       {getPerformanceIcon(team.performance)}
                       <span className={`text-lg font-bold ${


### PR DESCRIPTION
## Summary
- simplify team info row in `StandingsTab`
- use a single span for team name and players
- reduce row padding so the standings table is more compact

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686054c93fe08324961d0201ed218a41