### PR TITLE
Update print layout

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -89,7 +89,8 @@ export function MatchesTab({
             body { font-family: Arial, sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 20px; }
             table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-            th, td { padding: 12px; text-align: center; border: 1px solid #ddd; }
+            th, td { padding: 8px; text-align: center; border: 1px solid #000; }
+            th:nth-child(1), td:nth-child(1) { width: 10%; }
             th { background-color: #f2f2f2; font-weight: bold; }
             tr:nth-child(even) { background-color: #f9f9f9; }
             .score { font-size: 18px; font-weight: bold; text-align: center; }
@@ -112,11 +113,11 @@ export function MatchesTab({
                 <tr>
                   <td>${match.isBye ? '-' : match.court}</td>
                   <td>
-                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : `${getTeamName(match.team1Id)} : ${getTeamPlayers(match.team1Id, ' - ')}`}
+                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : `<strong>${getTeamName(match.team1Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team1Id, ' - ')}</div>`}
                   </td>
                   <td class="score">${match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}</td>
                   <td>
-                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `${getTeamName(match.team2Id)} : ${getTeamPlayers(match.team2Id, ' - ')}`}
+                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `<strong>${getTeamName(match.team2Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team2Id, ' - ')}</div>`}
                   </td>
                 </tr>
               `).join('')}


### PR DESCRIPTION
## Summary
- tweak `handlePrintRound` CSS to tighten spacing and show table borders
- show team name and players in print view similar to screen view

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686054c38bac8324b30824f711d9b343