### PR TITLE
Simplify team card layout

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -126,21 +126,23 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         {teams.map((team) => (
           <div
             key={team.id}
-            className="glass-card p-4 flex justify-between items-center hover:scale-[1.02] transition-all duration-300"
+            className="glass-card p-4 hover:scale-[1.02] transition-all duration-300"
           >
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="text-white font-medium">{team.name}</h3>
+              <button
+                onClick={() => onRemoveTeam(team.id)}
+                className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-lg hover:bg-red-400/10"
+                title={isSolo ? 'Supprimer le joueur' : "Supprimer l'équipe"}
+              >
+                <Trash2 className="w-5 h-5" />
+              </button>
+            </div>
             <p className="text-white font-medium">
-              {team.name}:{' '}
               {team.players
                 .map((player: Player) => `${player.name}${player.label ? ` [${player.label}]` : ''}`)
                 .join(' - ')}
             </p>
-            <button
-              onClick={() => onRemoveTeam(team.id)}
-              className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-lg hover:bg-red-400/10"
-              title={isSolo ? 'Supprimer le joueur' : "Supprimer l'équipe"}
-            >
-              <Trash2 className="w-5 h-5" />
-            </button>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- refactor TeamsTab team loop to use one card container

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686057e6bc908324bbe81ca9ea5a41c8