### PR TITLE
Reduce team card size

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -122,17 +122,17 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         </div>
       )}
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         {teams.map((team) => (
           <div
             key={team.id}
-            className="glass-card p-4 hover:scale-[1.02] transition-all duration-300"
+            className="glass-card p-3 hover:scale-[1.02] transition-all duration-300"
           >
-            <div className="flex justify-between items-center mb-2">
+            <div className="flex justify-between items-center mb-1">
               <h3 className="text-white font-medium">{team.name}</h3>
               <button
                 onClick={() => onRemoveTeam(team.id)}
-                className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-lg hover:bg-red-400/10"
+                className="text-red-400 hover:text-red-300 transition-colors p-1 rounded-lg hover:bg-red-400/10"
                 title={isSolo ? 'Supprimer le joueur' : "Supprimer l'équipe"}
               >
                 <Trash2 className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- shrink team card padding in TeamsTab
- tighten margins and gaps to keep layout readable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860623225588324acc2478bff25578e