### PR TITLE
Increase terrain options

### DIFF
--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -122,7 +122,7 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
               onChange={(e) => setCourts(Number(e.target.value))}
               className="glass-select w-full px-4 py-3 text-lg font-medium tracking-wide focus:outline-none"
             >
-              {Array.from({ length: 50 }, (_, i) => i + 1).map(num => (
+              {Array.from({ length: 150 }, (_, i) => i + 1).map(num => (
                 <option key={num} value={num} className="bg-slate-800">
                   {num} terrain{num > 1 ? 's' : ''}
                 </option>


### PR DESCRIPTION
## Summary
- expand the number of selectable terrains from 50 to 150 in TournamentSetup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860622329c483249c1d377e67f6e400