### PR TITLE
Fix font import order in styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 @layer base {
   * {


### PR DESCRIPTION
## Summary
- move the Google Fonts import to the top of `src/index.css`

## Testing
- `npm run build` *(fails: invalid JSX in TeamsTab.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6860747d10c08324a6025ef580bb82ed