### PR TITLE
Fix print alignment

### DIFF
--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -48,7 +48,11 @@ export function StandingsTab({ teams }: StandingsTabProps) {
               border-radius: 8px;
               overflow: hidden;
             }
-            .glass-table th, .glass-table td { border: 1px solid #ddd; }
+            .glass-table th, .glass-table td {
+              border: 1px solid #ddd;
+              border-left: 1px solid #ddd;
+              border-right: 1px solid #ddd;
+            }
             th, td { padding: 12px; }
             th { background-color: #f2f2f2; font-weight: bold; }
             tr:nth-child(even) { background-color: #f9f9f9; }

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -55,8 +55,8 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
           <title>Équipes</title>
           <style>
             body { font-family: Arial, sans-serif; margin: 20px; }
-            h1 { text-align: center; margin-bottom: 20px; }
-            .team { text-align: center; margin: 4px 0; padding: 6px; border: 1px solid #ccc; }
+            h1 { text-align: left; margin-bottom: 20px; }
+            .team { text-align: left; margin: 4px 0; padding: 6px; border: 1px solid #ccc; }
             @media print { body { margin: 0; } }
           </style>
         </head>


### PR DESCRIPTION
## Summary
- align printed player list with heading
- add vertical separators in printable standings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68608129de708324a6b01cb5759daf78