### PR TITLE
Fix duplicate name display

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -113,11 +113,21 @@ export function MatchesTab({
                 <tr>
                   <td>${match.isBye ? '-' : match.court}</td>
                   <td>
-                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : `<strong>${getTeamName(match.team1Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team1Id, ' - ')}</div>`}
+                    ${match.team1Ids
+                      ? getGroupLabel(match.team1Ids)
+                      : isSolo
+                      ? `<strong>${getTeamName(match.team1Id)}</strong>`
+                      : `<strong>${getTeamName(match.team1Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team1Id, ' - ')}</div>`}
                   </td>
                   <td class="score">${match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}</td>
                   <td>
-                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `<strong>${getTeamName(match.team2Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team2Id, ' - ')}</div>`}
+                    ${match.isBye
+                      ? 'BYE'
+                      : match.team2Ids
+                      ? getGroupLabel(match.team2Ids)
+                      : isSolo
+                      ? `<strong>${getTeamName(match.team2Id)}</strong>`
+                      : `<strong>${getTeamName(match.team2Id)}</strong><div style="font-size: 0.9em;">${getTeamPlayers(match.team2Id, ' - ')}</div>`}
                   </td>
                 </tr>
               `).join('')}
@@ -253,6 +263,8 @@ export function MatchesTab({
                       <td className="px-4 py-2 text-center">
                         {match.team1Ids
                           ? getGroupLabel(match.team1Ids)
+                          : isSolo
+                          ? getTeamName(match.team1Id)
                           : `${getTeamName(match.team1Id)} : ${getTeamPlayers(match.team1Id)}`}
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-center">
@@ -287,6 +299,8 @@ export function MatchesTab({
                           ? 'BYE'
                           : match.team2Ids
                           ? getGroupLabel(match.team2Ids)
+                          : isSolo
+                          ? getTeamName(match.team2Id)
                           : `${getTeamName(match.team2Id)} : ${getTeamPlayers(match.team2Id)}`}
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap text-center">

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -76,7 +76,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
               ${sortedTeams.map((team, index) => `
                 <tr class="${index < 3 ? 'podium' : ''}">
                   <td class="position">${index + 1}</td>
-                  <td>${team.name} : ${team.players.map(player => `${player.label ? `[${player.label}] ` : ''}${player.name}`).join(' - ')}</td>
+                  <td>${isSolo ? team.name : `${team.name} : ${team.players.map(player => `${player.label ? `[${player.label}] ` : ''}${player.name}`).join(' - ')}`}</td>
                   <td class="center">${team.wins}</td>
                   <td class="center">${team.losses}</td>
                   <td class="center">${team.pointsFor}</td>
@@ -158,13 +158,13 @@ export function StandingsTab({ teams }: StandingsTabProps) {
                   </td>
                   <td className="px-6 py-2 whitespace-nowrap">
                     <span className="font-bold text-white text-lg">
-                      {team.name}
-                      {team.players.length > 0 && ' - '}
-                      {team.players
-                        .map((player) =>
-                          `${player.label ? `[${player.label}] ` : ''}${player.name}`
-                        )
-                        .join(', ')}
+                      {isSolo
+                        ? team.name
+                        : `${team.name} - ${team.players
+                            .map((player) =>
+                              `${player.label ? `[${player.label}] ` : ''}${player.name}`
+                            )
+                            .join(', ')}`}
                     </span>
                   </td>
                   <td className="px-6 py-2 whitespace-nowrap text-center">


### PR DESCRIPTION
## Summary
- update matches and standings display logic to avoid repeating player names in tête-à-tête mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68608821465483249a880acf87bf3c4a