### PR TITLE
Ajout de tirets entre les noms des joueurs

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -32,7 +32,7 @@ export function MatchesTab({
     return team?.name || (isSolo ? 'Joueur inconnu' : 'Équipe inconnue');
   };
 
-  const getTeamPlayers = (teamId: string, separator = ', ') => {
+  const getTeamPlayers = (teamId: string, separator = ' - ') => {
     const team = teams.find(t => t.id === teamId);
     if (!team) return '';
     return team.players

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -164,7 +164,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
                             .map((player) =>
                               `${player.label ? `[${player.label}] ` : ''}${player.name}`
                             )
-                            .join(', ')}`}
+                            .join(' - ')}`}
                     </span>
                   </td>
                   <td className="px-6 py-2 whitespace-nowrap text-center">


### PR DESCRIPTION
## Summary
- afficher les joueurs d'une équipe séparés par des `-`
- mettre également ces tirets dans le tableau du classement

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68608b7838b8832482d4bd81103dedab