### PR TITLE
Add team editing feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
     generateRound,
     updateMatchScore,
     updateMatchCourt,
+    updateTeam,
     resetTournament,
   } = useTournament();
 
@@ -60,6 +61,7 @@ function App() {
             tournamentType={tournament.type}
             onAddTeam={addTeam}
             onRemoveTeam={removeTeam}
+            onUpdateTeam={updateTeam}
           />
         )}
         {activeTab === 'matches' && (

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -200,6 +200,27 @@ export function useTournament() {
     saveTournament(updatedTournament);
   };
 
+  const updateTeam = (teamId: string, players: Player[]) => {
+    if (!tournament) return;
+
+    const updatedTeams = tournament.teams.map((team, idx) => {
+      if (team.id === teamId) {
+        const name =
+          tournament.type === 'melee' || tournament.type === 'tete-a-tete'
+            ? `${idx + 1} - ${players[0].name}`
+            : team.name;
+        return { ...team, name, players };
+      }
+      return team;
+    });
+
+    const updatedTournament = {
+      ...tournament,
+      teams: updatedTeams,
+    };
+    saveTournament(updatedTournament);
+  };
+
   const resetTournament = () => {
     localStorage.removeItem(STORAGE_KEY);
     setTournament(null);
@@ -213,6 +234,7 @@ export function useTournament() {
     generateRound,
     updateMatchScore,
     updateMatchCourt,
+    updateTeam,
     resetTournament,
   };
 }


### PR DESCRIPTION
## Summary
- allow teams to be modified after creation
- show an edit button next to remove
- display edit form with existing player names

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6864262aa5408324afca8ccfa97b9de5