### PR TITLE
Fix team label formatting

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -47,7 +47,7 @@ export function MatchesTab({
       const team = teams.find(t => t.id === id);
       return team?.name || team?.players[0]?.name || 'Inconnu';
     });
-    return labels.join(' + ');
+    return labels.join(' - ');
   };
 
   const handleEditScore = (match: Match) => {

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -45,7 +45,7 @@ export function useTournament() {
     const teamNumber = tournament.teams.length + 1;
     const teamName =
       tournament.type === 'melee' || tournament.type === 'tete-a-tete'
-        ? `${teamNumber} - ${players[0].name}`
+        ? `${teamNumber}: ${players[0].name}`
         : `Équipe ${teamNumber}`;
 
     const team: Team = {
@@ -77,7 +77,7 @@ export function useTournament() {
       ...team,
       name:
         tournament.type === 'melee' || tournament.type === 'tete-a-tete'
-          ? `${index + 1} - ${team.players[0].name}`
+          ? `${index + 1}: ${team.players[0].name}`
           : `Équipe ${index + 1}`,
     }));
 
@@ -283,7 +283,7 @@ export function useTournament() {
       if (team.id === teamId) {
         const name =
           tournament.type === 'melee' || tournament.type === 'tete-a-tete'
-            ? `${idx + 1} - ${players[0].name}`
+            ? `${idx + 1}: ${players[0].name}`
             : team.name;
         return { ...team, name, players };
       }


### PR DESCRIPTION
## Summary
- show melee and tête-à-tête team numbers with a colon
- join group labels with dashes instead of plus signs

## Testing
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68642eea26b08324ad1c47fb2ca46dbc