### PR TITLE
Remove 'Équipe' prefix in matches

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -31,7 +31,14 @@ export function MatchesTab({
 
   const getTeamName = (teamId: string) => {
     const team = teams.find(t => t.id === teamId);
-    return team?.name || (isSolo ? 'Joueur inconnu' : 'Équipe inconnue');
+    if (!team) {
+      return isSolo ? 'Joueur inconnu' : 'Équipe inconnue';
+    }
+    const name = team.name;
+    if (!isSolo && name.toLowerCase().startsWith('équipe ')) {
+      return name.replace(/^Équipe\s+/i, '');
+    }
+    return name;
   };
 
   const getTeamPlayers = (teamId: string, separator = ' - ') => {
@@ -45,7 +52,12 @@ export function MatchesTab({
   const getGroupLabel = (ids: string[]) => {
     const labels = ids.map(id => {
       const team = teams.find(t => t.id === id);
-      return team?.name || team?.players[0]?.name || 'Inconnu';
+      if (!team) return 'Inconnu';
+      const name = team.name || team.players[0]?.name || 'Inconnu';
+      if (!isSolo && name.toLowerCase().startsWith('équipe ')) {
+        return name.replace(/^Équipe\s+/i, '');
+      }
+      return name;
     });
     return labels.join(' - ');
   };


### PR DESCRIPTION
## Summary
- show only the team number in match listings for team tournaments
- apply same formatting when printing matches

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864398181c48324a2809e8b905f88cc