### PR TITLE
Remove free court rows from print

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -91,12 +91,6 @@ export function MatchesTab({
 
   const handlePrintRound = (round: number) => {
     const roundMatches = groupedMatches[round];
-    const occupiedCourts = roundMatches
-      .filter(m => m.court > 0 && m.court <= courts)
-      .map(m => m.court);
-    const freeCourts = Array.from({ length: courts }, (_, i) => i + 1).filter(
-      c => !occupiedCourts.includes(c)
-    );
     const printWindow = window.open('', '_blank');
     if (!printWindow) return;
 
@@ -137,15 +131,6 @@ export function MatchesTab({
       )
       .join('');
 
-    const freeCourtRows = freeCourts
-      .map(
-        court => `
-                <tr>
-                  <td>${court}</td><td colspan="3">Terrain libre</td>
-                </tr>
-              `
-      )
-      .join('');
 
     const printContent = `
       <!DOCTYPE html>
@@ -176,7 +161,7 @@ export function MatchesTab({
               </tr>
             </thead>
             <tbody>
-              ${matchRows}${freeCourtRows}
+              ${matchRows}
             </tbody>
           </table>
           <div style="text-align: center; margin-top: 20px;">


### PR DESCRIPTION
## Summary
- fix print output to omit unused courts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68643b84a4d083249562df090b58c13f