### PR TITLE
Handle leftover group bye

### DIFF
--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -334,17 +334,18 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
     matchesResult.push({
       id: crypto.randomUUID(),
       round,
-      court: courtIndex,
+      court: 0,
       team1Id: teamIds[0],
       team2Id: teamIds[0],
       team1Ids: teamIds,
       team2Ids: teamIds,
-      completed: false,
-      isBye: false,
+      team1Score: 13,
+      team2Score: 7,
+      completed: true,
+      isBye: true,
       battleIntensity: 0,
       hackingAttempts: 0,
     });
-    courtIndex++;
   }
 
   return matchesResult;


### PR DESCRIPTION
## Summary
- treat leftover melee group as a BYE round with default scores
- mark as BYE in matchmaking logic

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68644d83d078832482d5ed9b5e0f9386