### PR TITLE
Add poule tournament configuration

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -21,8 +21,10 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam, onUpd
       case 'tete-a-tete':
         return 1;
       case 'doublette':
+      case 'doublette-poule':
         return 2;
       case 'triplette':
+      case 'triplette-poule':
         return 3;
       case 'quadrette':
         return 4;

--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -4,16 +4,23 @@ import { Users, Target, Trophy, Shield } from 'lucide-react';
 import { Logo } from './Logo';
 
 interface TournamentSetupProps {
-  onCreateTournament: (type: TournamentType, courts: number) => void;
+  onCreateTournament: (
+    type: TournamentType,
+    courts: number,
+    pools?: number,
+    teamsPerPool?: number,
+  ) => void;
 }
 
 export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
   const [type, setType] = useState<TournamentType>('doublette');
   const [courts, setCourts] = useState(4);
+  const [pools, setPools] = useState(2);
+  const [teamsPerPool, setTeamsPerPool] = useState(3);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onCreateTournament(type, courts);
+    onCreateTournament(type, courts, pools, teamsPerPool);
   };
 
   const tournamentTypes = [
@@ -24,19 +31,33 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
       players: '1 joueur par équipe',
       description: 'Duel individuel'
     },
-    { 
-      value: 'doublette', 
-      label: 'Doublette', 
-      icon: Users, 
+    {
+      value: 'doublette',
+      label: 'Doublette',
+      icon: Users,
       players: '2 joueurs par équipe',
       description: 'Jeu en binôme'
     },
-    { 
-      value: 'triplette', 
-      label: 'Triplette', 
-      icon: Users, 
+    {
+      value: 'doublette-poule',
+      label: 'Doublette (poules)',
+      icon: Users,
+      players: '2 joueurs par équipe',
+      description: 'Phase de poules en doublette'
+    },
+    {
+      value: 'triplette',
+      label: 'Triplette',
+      icon: Users,
       players: '3 joueurs par équipe',
       description: 'Formation classique'
+    },
+    {
+      value: 'triplette-poule',
+      label: 'Triplette (poules)',
+      icon: Users,
+      players: '3 joueurs par équipe',
+      description: 'Phase de poules en triplette'
     },
     { 
       value: 'quadrette', 
@@ -111,24 +132,53 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
                 );
               })}
             </div>
-          </div>
+            </div>
 
-          <div className="glass-card p-3">
-            <label className="block text-lg font-bold text-white mb-4 tracking-wide">
-              Nombre de terrains
-            </label>
-            <select
-              value={courts}
-              onChange={(e) => setCourts(Number(e.target.value))}
-              className="glass-select w-full px-4 py-3 text-lg font-medium tracking-wide focus:outline-none"
-            >
-              {Array.from({ length: 150 }, (_, i) => i + 1).map(num => (
-                <option key={num} value={num} className="bg-slate-800">
-                  {num} terrain{num > 1 ? 's' : ''}
-                </option>
-              ))}
-            </select>
-          </div>
+            <div className="glass-card p-3">
+              <label className="block text-lg font-bold text-white mb-4 tracking-wide">
+                Nombre de terrains
+              </label>
+              <select
+                value={courts}
+                onChange={(e) => setCourts(Number(e.target.value))}
+                className="glass-select w-full px-4 py-3 text-lg font-medium tracking-wide focus:outline-none"
+              >
+                {Array.from({ length: 150 }, (_, i) => i + 1).map(num => (
+                  <option key={num} value={num} className="bg-slate-800">
+                    {num} terrain{num > 1 ? 's' : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {(type === 'doublette-poule' || type === 'triplette-poule') && (
+              <div className="glass-card p-3 space-y-4">
+                <div>
+                  <label className="block text-lg font-bold text-white mb-2 tracking-wide">
+                    Nombre de poules
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={pools}
+                    onChange={e => setPools(Number(e.target.value))}
+                    className="glass-input w-full px-4 py-3 text-lg font-medium tracking-wide"
+                  />
+                </div>
+                <div>
+                  <label className="block text-lg font-bold text-white mb-2 tracking-wide">
+                    Équipes par poule
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={teamsPerPool}
+                    onChange={e => setTeamsPerPool(Number(e.target.value))}
+                    className="glass-input w-full px-4 py-3 text-lg font-medium tracking-wide"
+                  />
+                </div>
+              </div>
+            )}
 
           <button
             type="submit"

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -21,13 +21,20 @@ export function useTournament() {
     setTournament(tournament);
   };
 
-  const createTournament = (type: TournamentType, courts: number) => {
+  const createTournament = (
+    type: TournamentType,
+    courts: number,
+    pools?: number,
+    teamsPerPool?: number,
+  ) => {
     const defaultName = `Tournoi ${new Date().toLocaleDateString()}`;
     const newTournament: Tournament = {
       id: crypto.randomUUID(),
       name: defaultName,
       type,
       courts,
+      pools,
+      teamsPerPool,
       teams: [],
       matches: [],
       currentRound: 0,

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -1,4 +1,11 @@
-export type TournamentType = 'tete-a-tete' | 'doublette' | 'triplette' | 'quadrette' | 'melee';
+export type TournamentType =
+  | 'tete-a-tete'
+  | 'doublette'
+  | 'triplette'
+  | 'quadrette'
+  | 'melee'
+  | 'doublette-poule'
+  | 'triplette-poule';
 
 export interface CyberImplant {
   id: string;
@@ -55,6 +62,8 @@ export interface Tournament {
   name: string;
   type: TournamentType;
   courts: number;
+  pools?: number;
+  teamsPerPool?: number;
   teams: Team[];
   matches: Match[];
   currentRound: number;


### PR DESCRIPTION
## Summary
- support new tournament types `doublette-poule` and `triplette-poule`
- allow specifying number of pools and teams per pool
- pass new settings through tournament creation

## Testing
- `npm run lint`
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_6865b55d8ce883249f75df262a75fcd8