### PR TITLE
Add pools to tournament data

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -12,6 +12,7 @@ export function useTournament() {
     if (saved) {
       const parsed = JSON.parse(saved);
       parsed.createdAt = new Date(parsed.createdAt);
+      if (!parsed.pools) parsed.pools = [];
       setTournament(parsed);
     }
   }, []);
@@ -29,6 +30,7 @@ export function useTournament() {
       type,
       courts,
       teams: [],
+      pools: [],
       matches: [],
       currentRound: 0,
       completed: false,

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -34,9 +34,16 @@ export interface Team {
   synchroLevel: number;
 }
 
+export interface Pool {
+  id: string;
+  teamIds: string[];
+}
+
 export interface Match {
   id: string;
   round: number;
+  day?: number;
+  poolId?: string;
   court: number;
   team1Id: string;
   team2Id: string;
@@ -56,6 +63,7 @@ export interface Tournament {
   type: TournamentType;
   courts: number;
   teams: Team[];
+  pools: Pool[];
   matches: Match[];
   currentRound: number;
   completed: boolean;


### PR DESCRIPTION
## Summary
- define `Pool` type
- track `day` and `poolId` in `Match`
- store an array of pools on `Tournament`
- persist pools when (de)serializing tournaments

## Testing
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_6865b561d4608324ae50bac0a560db8b