### PR TITLE
Add automatic pool generation

### DIFF
--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -4,12 +4,9 @@ export type TournamentType =
   | 'triplette'
   | 'quadrette'
   | 'melee'
-        codex/créer-fonction-generatepoolmatches-pour-round-robin
-  | 'pool';
-
+  | 'pool'
   | 'doublette-poule'
   | 'triplette-poule';
-        main
 
 export interface CyberImplant {
   id: string;


### PR DESCRIPTION
## Summary
- auto-split teams into pools of 3-4 teams
- run automatic pool creation when starting a `doublette-poule` or `triplette-poule` tournament
- clean up tournament type definitions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865bcc3093c83248980690a7eadf35f