### PR TITLE
Handle pool play types

### DIFF
--- a/manual-tests/poolRoundRobin.ts
+++ b/manual-tests/poolRoundRobin.ts
@@ -1,0 +1,54 @@
+import { generateMatches } from '../src/utils/matchmaking.ts';
+import { Tournament, Team, Pool } from '../src/types/tournament';
+
+function createTeam(id: string, poolId: string): Team {
+  return {
+    id,
+    name: id,
+    poolId,
+    players: [],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  } as Team;
+}
+
+const teams: Team[] = [
+  createTeam('A1', 'A'),
+  createTeam('A2', 'A'),
+  createTeam('A3', 'A'),
+  createTeam('A4', 'A'),
+];
+
+const tournament: Tournament = {
+  id: 't1',
+  name: 'Test',
+  type: 'doublette-poule',
+  courts: 2,
+  teams,
+  pools: [{ id: 'A', teamIds: teams.map(t => t.id) }],
+  matches: [],
+  currentRound: 0,
+  completed: false,
+  createdAt: new Date(),
+  securityLevel: 0,
+  networkStatus: 'online',
+};
+
+for (let day = 1; day <= 3; day++) {
+  const newMatches = generateMatches(tournament);
+  console.log(`Day ${day}`);
+  newMatches.forEach(m => console.log(`  ${m.team1Id} vs ${m.team2Id} (pool ${m.poolId})`));
+  tournament.matches.push(...newMatches);
+  tournament.currentRound++;
+}
+
+const pairs = new Set(tournament.matches
+  .filter(m => !m.isBye)
+  .map(m => [m.team1Id, m.team2Id].sort().join('-')));
+
+console.log('Unique pairings:', pairs);

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -4,12 +4,9 @@ export type TournamentType =
   | 'triplette'
   | 'quadrette'
   | 'melee'
-        codex/créer-fonction-generatepoolmatches-pour-round-robin
-  | 'pool';
-
+  | 'pool'
   | 'doublette-poule'
   | 'triplette-poule';
-        main
 
 export interface CyberImplant {
   id: string;
@@ -59,8 +56,6 @@ export interface Match {
   day?: number;
   poolId?: string;
   court: number;
-  poolId?: string;
-  day?: number;
   team1Id: string;
   team2Id: string;
   team1Ids?: string[];
@@ -71,11 +66,6 @@ export interface Match {
   isBye: boolean;
   battleIntensity: number;
   hackingAttempts: number;
-}
-
-export interface Pool {
-  id: string;
-  teamIds: string[];
 }
 
 export interface Tournament {
@@ -95,6 +85,5 @@ export interface Tournament {
   createdAt: Date;
   securityLevel: number;
   networkStatus: 'online' | 'offline' | 'compromised';
-  pools?: Pool[];
   stage?: 'pool' | 'knockout' | 'finished';
 }

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -3,6 +3,8 @@ import { Tournament, Match, Team } from '../types/tournament';
 export function generateMatches(tournament: Tournament): Match[] {
   switch (tournament.type) {
     case 'pool':
+    case 'doublette-poule':
+    case 'triplette-poule':
       return generatePoolMatches(tournament);
     case 'quadrette':
       return generateQuadretteMatches(tournament);


### PR DESCRIPTION
## Summary
- call `generatePoolMatches` for `doublette-poule` and `triplette-poule` tournament types
- fix `TournamentType` definition and clean duplicates in types
- add manual test script verifying round‑robin scheduling

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS='{ "module": "esnext" }' node --loader ts-node/esm manual-tests/poolRoundRobin.ts`

------
https://chatgpt.com/codex/tasks/task_e_6865bcbe26988324b8e3bcaac660e7c3