### PR TITLE
Group matches by pool and round

### DIFF
--- a/manual-tests/poolRoundRobin.ts
+++ b/manual-tests/poolRoundRobin.ts
@@ -1,5 +1,5 @@
 import { generateMatches } from '../src/utils/matchmaking.ts';
-import { Tournament, Team, Pool } from '../src/types/tournament';
+import { Tournament, Team } from '../src/types/tournament';
 
 function createTeam(id: string, poolId: string): Team {
   return {

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -4,20 +4,9 @@ export type TournamentType =
   | 'triplette'
   | 'quadrette'
   | 'melee'
-        codex/mettre-à-jour-generatematches-pour--doublette-poule--et--tri
   | 'pool'
   | 'doublette-poule'
   | 'triplette-poule';
-        codex/implémenter-fonction-createpoolsautomatically
-  | 'pool'
-  | 'doublette-poule'
-  | 'triplette-poule';
-
-  | 'doublette-poule'
-  | 'triplette-poule'
-  | 'pool';
-        main
-        main
 
 export interface CyberImplant {
   id: string;


### PR DESCRIPTION
## Summary
- group matches by both round and pool
- print grouped pools per round
- render tables per pool in Matches tab
- fix linter issues

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865c4d7ea9c83249b1e464ebf9838f5