### PR TITLE
Fix BYE assignment after pool completion

### DIFF
--- a/src/utils/__tests__/finals.test.ts
+++ b/src/utils/__tests__/finals.test.ts
@@ -1,0 +1,47 @@
+import { applyByeLogic } from '../finals';
+import { Match } from '../../types/tournament';
+
+describe('applyByeLogic', () => {
+  function makeMatch(id: string, team1Id = '', team2Id = ''): Match {
+    return {
+      id,
+      round: 100,
+      court: 0,
+      team1Id,
+      team2Id,
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+  }
+
+  it('does not assign BYE when pools still have matches', () => {
+    const matches = [
+      makeMatch('m1', 't1'),
+      makeMatch('m2', 't2'),
+      makeMatch('m3'),
+      makeMatch('m4'),
+    ];
+
+    const result = applyByeLogic(matches, 3, 6, 1);
+    expect(result.some(m => m.isBye)).toBe(false);
+  });
+
+  it('assigns BYE after pools conclude', () => {
+    const matches = [
+      makeMatch('m1', 't1', 't4'),
+      makeMatch('m2', 't2', 't5'),
+      makeMatch('m3', 't3'),
+      makeMatch('m4', 't6'),
+    ];
+
+    const result = applyByeLogic(matches, 6, 6, 0);
+    const byeMatches = result.filter(m => m.isBye);
+    expect(byeMatches).toHaveLength(2);
+    byeMatches.forEach(m => {
+      expect(m.team1Id).toBe(m.team2Id);
+      expect(m.completed).toBe(true);
+    });
+  });
+});

--- a/src/utils/finals.ts
+++ b/src/utils/finals.ts
@@ -1,0 +1,33 @@
+import { Match } from '../types/tournament';
+
+export function countEmptySlots(matches: Match[]): number {
+  return matches.reduce((acc, m) => {
+    if (!m.team1Id) acc += 1;
+    if (!m.team2Id) acc += 1;
+    return acc;
+  }, 0);
+}
+
+export function applyByeLogic(matches: Match[], qualifiedCount: number, expectedQualified: number, pendingPoolMatches: number): Match[] {
+  const remainingSlots = countEmptySlots(matches);
+
+  if (pendingPoolMatches === 0 && qualifiedCount + remainingSlots >= expectedQualified) {
+    return matches.map(match => {
+      if (!match.completed && ((match.team1Id && !match.team2Id) || (!match.team1Id && match.team2Id))) {
+        const solo = match.team1Id || match.team2Id || '';
+        return {
+          ...match,
+          team1Id: solo,
+          team2Id: solo,
+          team1Score: 13,
+          team2Score: 0,
+          completed: true,
+          isBye: true,
+        };
+      }
+      return match;
+    });
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- adjust final phase update to wait for pools to finish before turning single-team matches into BYEs
- expose BYE logic helper
- add regression tests for BYE assignment timing

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686828065b1c832498b405622a8c124d