### PR TITLE
Refactor pool calculations and bye logic

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Tournament, TournamentType, Team, Player, Match } from '../types/tournament';
 import { generateMatches } from '../utils/matchmaking';
-import { generatePools } from '../utils/poolGeneration';
+import { generatePools, calculateOptimalPools } from '../utils/poolGeneration';
 import { applyByeLogic } from '../utils/finals';
 
 const STORAGE_KEY = 'petanque-tournament';
@@ -213,16 +213,7 @@ export function useTournament() {
     const matches: Match[] = [];
 
     // Calculer le nombre d'équipes qualifiées attendues
-    const poolsOf4 = Math.floor(totalTeams / 4);
-    const remainder = totalTeams % 4;
-    let poolsOf3 = 0;
-
-    if (remainder === 1 || remainder === 2) {
-      poolsOf3 = 2;
-    } else if (remainder === 3) {
-      poolsOf3 = 1;
-    }
-
+    const { poolsOf4, poolsOf3 } = calculateOptimalPools(totalTeams);
     const expectedQualified = (poolsOf4 + poolsOf3) * 2;
 
     // Taille du tableau : puissance de deux immédiatement supérieure
@@ -392,16 +383,7 @@ export function useTournament() {
 
     // Calculer le nombre d'équipes qualifiées attendues comme dans createEmptyFinalPhases
     const totalTeams = updatedTournament.teams.length;
-    const poolsOf4 = Math.floor(totalTeams / 4);
-    const remainder = totalTeams % 4;
-    let poolsOf3 = 0;
-
-    if (remainder === 1 || remainder === 2) {
-      poolsOf3 = 2;
-    } else if (remainder === 3) {
-      poolsOf3 = 1;
-    }
-
+    const { poolsOf4, poolsOf3 } = calculateOptimalPools(totalTeams);
     const expectedQualified = (poolsOf4 + poolsOf3) * 2;
     
     // Obtenir les matchs des phases finales (round >= 100)

--- a/src/utils/__tests__/finals.test.ts
+++ b/src/utils/__tests__/finals.test.ts
@@ -44,4 +44,21 @@ describe('applyByeLogic', () => {
       expect(m.completed).toBe(true);
     });
   });
+
+  it('assigns four BYEs for a 21 team tournament', () => {
+    const matches = [
+      makeMatch('m1', 't1', 't2'),
+      makeMatch('m2', 't3', 't4'),
+      makeMatch('m3', 't5', 't6'),
+      makeMatch('m4', 't7'),
+      makeMatch('m5', 't8'),
+      makeMatch('m6', 't9', 't10'),
+      makeMatch('m7', 't11'),
+      makeMatch('m8', 't12'),
+    ];
+
+    const result = applyByeLogic(matches, 12, 12, 0);
+    const byeMatches = result.filter(m => m.isBye);
+    expect(byeMatches).toHaveLength(4);
+  });
 });

--- a/src/utils/poolGeneration.ts
+++ b/src/utils/poolGeneration.ts
@@ -43,7 +43,7 @@ export function generatePools(teams: Team[]): Pool[] {
   return pools;
 }
 
-function calculateOptimalPools(totalTeams: number): { poolsOf4: number; poolsOf3: number } {
+export function calculateOptimalPools(totalTeams: number): { poolsOf4: number; poolsOf3: number } {
   // Start with as many pools of 4 as possible
   let poolsOf4 = Math.floor(totalTeams / 4);
   let remainder = totalTeams % 4;


### PR DESCRIPTION
## Summary
- export `calculateOptimalPools`
- use `calculateOptimalPools` to compute finals structure in `useTournament`
- update finals tests for bye logic with 21 teams

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68683ec569648324b026efb5847c6506