### PR TITLE
Switch pool names from letters to numbers

### DIFF
--- a/src/utils/__tests__/poolGeneration.test.ts
+++ b/src/utils/__tests__/poolGeneration.test.ts
@@ -44,7 +44,7 @@ describe('generatePools', () => {
 describe('generatePoolMatches', () => {
   it('schedules round robin matches for a pool of four', () => {
     const teams = makeTeams(4);
-    const pool = { id: 'A', name: 'A', teamIds: teams.map(t => t.id), matches: [] };
+    const pool = { id: '1', name: 'Poule 1', teamIds: teams.map(t => t.id), matches: [] };
     const matches = generatePoolMatches(pool, teams);
     expect(matches).toHaveLength(6); // 4 choose 2
     const pairings = new Set(matches.map(m => [m.team1Id, m.team2Id].sort().join('-')));
@@ -53,7 +53,7 @@ describe('generatePoolMatches', () => {
 
   it('schedules round robin matches for a pool of three', () => {
     const teams = makeTeams(3);
-    const pool = { id: 'A', name: 'A', teamIds: teams.map(t => t.id), matches: [] };
+    const pool = { id: '1', name: 'Poule 1', teamIds: teams.map(t => t.id), matches: [] };
     const matches = generatePoolMatches(pool, teams);
     expect(matches).toHaveLength(3); // 3 choose 2
     const pairings = new Set(matches.map(m => [m.team1Id, m.team2Id].sort().join('-')));

--- a/src/utils/poolGeneration.ts
+++ b/src/utils/poolGeneration.ts
@@ -21,7 +21,7 @@ export function generatePools(teams: Team[]): Pool[] {
     const poolTeams = shuffledTeams.slice(teamIndex, teamIndex + 4);
     pools.push({
       id: crypto.randomUUID(),
-      name: `Poule ${String.fromCharCode(65 + i)}`, // A, B, C, etc.
+      name: `Poule ${i + 1}`,
       teamIds: poolTeams.map(t => t.id),
       matches: []
     });
@@ -33,7 +33,7 @@ export function generatePools(teams: Team[]): Pool[] {
     const poolTeams = shuffledTeams.slice(teamIndex, teamIndex + 3);
     pools.push({
       id: crypto.randomUUID(),
-      name: `Poule ${String.fromCharCode(65 + poolsOf4 + i)}`,
+      name: `Poule ${poolsOf4 + i + 1}`,
       teamIds: poolTeams.map(t => t.id),
       matches: []
     });


### PR DESCRIPTION
## Summary
- update pool generation to use numbered names
- adjust tests for numeric naming

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68684d2b5b148324801f07d0880e5a3c