### PR TITLE
Add finals editing and court availability

### DIFF
--- a/src/components/CourtAvailability.tsx
+++ b/src/components/CourtAvailability.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Match } from '../types/tournament';
+
+interface CourtAvailabilityProps {
+  courts: number;
+  matches: Match[];
+}
+
+export function CourtAvailability({ courts, matches }: CourtAvailabilityProps) {
+  const isOccupied = (court: number) =>
+    matches.some(m => m.court === court && !m.completed && !m.isBye);
+
+  return (
+    <div className="flex space-x-2 overflow-x-auto pb-2">
+      {Array.from({ length: courts }, (_, i) => i + 1).map(court => (
+        <span
+          key={court}
+          className={`px-2 py-1 rounded text-sm font-bold ${isOccupied(court) ? 'bg-red-500' : 'bg-green-600'} text-white`}
+        >
+          {court}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show terrain availability between pools and finals
- make winner modal smaller
- allow editing and court selection in finals
- position winner selection near cursor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696f5acd988324abc5e8ea00ef6e23