### PR TITLE
Implement UUID helper

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Player, Team, TournamentType } from '../types/tournament';
+import { generateUuid } from '../utils/uuid';
 import { Plus, Trash2, Users, Printer, X } from 'lucide-react';
 
 interface TeamsTabProps {
@@ -194,7 +195,7 @@ function CompactTeamForm({ tournamentType, playersPerTeam, onAddTeam, onClose }:
     if (validNames.length === 0) return;
 
     const players: Player[] = validNames.map((name, index) => ({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       name: name.trim(),
       label: labels?.[index],
       cyberImplants: [],

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -3,6 +3,7 @@ import { Tournament, TournamentType, Team, Player, Match } from '../types/tourna
 import { generateMatches } from '../utils/matchmaking';
 import { generatePools, calculateOptimalPools } from '../utils/poolGeneration';
 import { applyByeLogic } from '../utils/finals';
+import { generateUuid } from '../utils/uuid';
 
 const STORAGE_KEY = 'petanque-tournament';
 
@@ -31,7 +32,7 @@ export function useTournament() {
   const createTournament = (type: TournamentType, courts: number) => {
     const defaultName = `Tournoi ${new Date().toLocaleDateString()}`;
     const newTournament: Tournament = {
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       name: defaultName,
       type,
       courts,
@@ -58,7 +59,7 @@ export function useTournament() {
         : `Équipe ${teamNumber}`;
 
     const team: Team = {
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       name: teamName,
       players,
       wins: 0,
@@ -126,7 +127,7 @@ export function useTournament() {
         
         // Match 1 vs 4
         allMatches.push({
-          id: crypto.randomUUID(),
+          id: generateUuid(),
           round: 1,
           court: baseCourt,
           team1Id: team1!.id,
@@ -140,7 +141,7 @@ export function useTournament() {
         
         // Match 2 vs 3
         allMatches.push({
-          id: crypto.randomUUID(),
+          id: generateUuid(),
           round: 1,
           court: baseCourt + 1,
           team1Id: team2!.id,
@@ -159,7 +160,7 @@ export function useTournament() {
         
         // Match entre les 2 premières équipes
         allMatches.push({
-          id: crypto.randomUUID(),
+          id: generateUuid(),
           round: 1,
           court: baseCourt,
           team1Id: team1!.id,
@@ -173,7 +174,7 @@ export function useTournament() {
         
         // L'équipe 3 reçoit un BYE automatique (1 victoire) mais doit encore jouer
         allMatches.push({
-          id: crypto.randomUUID(),
+          id: generateUuid(),
           round: 1,
           court: 0, // Court 0 = match virtuel
           team1Id: team3!.id,
@@ -225,7 +226,7 @@ export function useTournament() {
       
       for (let i = 0; i < matchesInRound; i++) {
         matches.push({
-          id: crypto.randomUUID(),
+          id: generateUuid(),
           round,
           court: courtIndex,
           team1Id: '', // Vide au début
@@ -313,7 +314,7 @@ export function useTournament() {
             // Generate winners match
             if (!winnersMatchExists) {
               allMatches.push({
-                id: crypto.randomUUID(),
+                id: generateUuid(),
                 round: 2,
                 court: baseCourt,
                 team1Id: winner1vs4.id,
@@ -329,7 +330,7 @@ export function useTournament() {
             // Generate losers match
             if (!losersMatchExists) {
               allMatches.push({
-                id: crypto.randomUUID(),
+                id: generateUuid(),
                 round: 2,
                 court: baseCourt + 1,
                 team1Id: loser1vs4.id,
@@ -716,7 +717,7 @@ export function useTournament() {
           // Generate winners match (Finale)
           if (!winnersMatchExists) {
             allMatches.push({
-              id: crypto.randomUUID(),
+              id: generateUuid(),
               round: 2,
               court: baseCourt,
               team1Id: winner1vs4.id,
@@ -732,7 +733,7 @@ export function useTournament() {
           // Generate losers match (Petite finale)
           if (!losersMatchExists) {
             allMatches.push({
-              id: crypto.randomUUID(),
+              id: generateUuid(),
               round: 2,
               court: baseCourt + 1,
               team1Id: loser1vs4.id,
@@ -781,7 +782,7 @@ export function useTournament() {
 
             if (!barrageExists) {
               allMatches.push({
-                id: crypto.randomUUID(),
+                id: generateUuid(),
                 round: 3,
                 court: baseCourt,
                 team1Id: teamsWithOneWin[0].team.id,
@@ -834,7 +835,7 @@ export function useTournament() {
           
           if (!winnersMatchExists) {
             allMatches.push({
-              id: crypto.randomUUID(),
+              id: generateUuid(),
               round: 2,
               court: baseCourt,
               team1Id: winner.id,
@@ -855,7 +856,7 @@ export function useTournament() {
           
           if (!loserByeExists) {
             allMatches.push({
-              id: crypto.randomUUID(),
+              id: generateUuid(),
               round: 2,
               court: 0, // Court 0 = match virtuel
               team1Id: loser.id,
@@ -932,7 +933,7 @@ export function useTournament() {
 
               if (!barrageExists) {
                 allMatches.push({
-                  id: crypto.randomUUID(),
+                  id: generateUuid(),
                   round: 3,
                   court: baseCourt,
                   team1Id: teamsWithOneWin[0].team.id,

--- a/src/utils/__tests__/uuid.test.ts
+++ b/src/utils/__tests__/uuid.test.ts
@@ -1,0 +1,8 @@
+import { generateUuid } from '../uuid';
+
+describe('generateUuid', () => {
+  it('produces unique values', () => {
+    const ids = new Set(Array.from({ length: 10 }, () => generateUuid()));
+    expect(ids.size).toBe(10);
+  });
+});

--- a/src/utils/bracket.ts
+++ b/src/utils/bracket.ts
@@ -1,4 +1,5 @@
 import { Pool, Team, Match } from '../types/tournament';
+import { generateUuid } from './uuid';
 
 export function getTopTeamsFromPools(pools: Pool[], allTeams: Team[], qualifiersPerPool: number): Team[] {
   const idToTeam = new Map(allTeams.map(t => [t.id, t]));
@@ -34,7 +35,7 @@ export function createKnockoutBracket(teams: Team[], startingRound = 1): Match[]
   for (let i = 0; i < byesNeeded; i++) {
     const t1 = teams[teamIndex++];
     firstRound.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: 0,
       team1Id: t1.id,
@@ -52,7 +53,7 @@ export function createKnockoutBracket(teams: Team[], startingRound = 1): Match[]
     const t1 = teams[teamIndex];
     const t2 = teams[teamIndex + 1];
     firstRound.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: 0,
       team1Id: t1.id,
@@ -88,7 +89,7 @@ export function createKnockoutBracket(teams: Team[], startingRound = 1): Match[]
             : '';
 
       nextMatches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: 0,
         team1Id: winner1,

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -1,4 +1,5 @@
 import { Tournament, Match, Team } from '../types/tournament';
+import { generateUuid } from './uuid';
 
 export function generateMatches(tournament: Tournament): Match[] {
   switch (tournament.type) {
@@ -26,7 +27,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
     if (remainingTeams.length % 2 === 1) {
       const byeTeam = remainingTeams.pop() as Team;
       newMatches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: 0,
         team1Id: byeTeam.id,
@@ -48,7 +49,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
       const t1 = remainingTeams[i];
       const t2 = remainingTeams[i + 2];
       newMatches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: courtIndex++,
         team1Id: t1.id,
@@ -62,7 +63,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
       const t3 = remainingTeams[i + 1];
       const t4 = remainingTeams[i + 3];
       newMatches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: courtIndex++,
         team1Id: t3.id,
@@ -79,7 +80,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
       const t1 = remainingTeams[i];
       const t2 = remainingTeams[i + 1];
       newMatches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: courtIndex++,
         team1Id: t1.id,
@@ -99,7 +100,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
     const byeTeam = remainingTeams[remainingTeams.length - 1];
 
     newMatches.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: 0,
       team1Id: byeTeam.id,
@@ -131,7 +132,7 @@ function generateStandardMatches(tournament: Tournament): Match[] {
     const [team2] = remainingTeams.splice(opponentIndex, 1);
 
     newMatches.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: courtIndex,
       team1Id: team1.id,
@@ -194,7 +195,7 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
         for (let i = 0; i < subTeamIds.length - 1; i += 2) {
           if (subTeamIds[i + 1]) {
             newMatches.push({
-              id: crypto.randomUUID(),
+              id: generateUuid(),
               round,
               court: ((courtIndex - 1) % courts) + 1,
               team1Id: subTeamIds[i],
@@ -283,7 +284,7 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
       groups.splice(second, 1);
 
       matchesResult.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round,
         court: courtIndex,
         team1Id: groupA[0],
@@ -313,7 +314,7 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
     const team2Ids = groups.splice(opponentIndex, 1)[0];
 
     matchesResult.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: courtIndex,
       team1Id: team1Ids[0],
@@ -332,7 +333,7 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
   if (groups.length === 1) {
     const teamIds = groups.shift()!;
     matchesResult.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       round,
       court: courtIndex,
       team1Id: teamIds[0],

--- a/src/utils/poolGeneration.ts
+++ b/src/utils/poolGeneration.ts
@@ -1,4 +1,5 @@
 import { Team, Pool, Match } from '../types/tournament';
+import { generateUuid } from './uuid';
 
 export function generatePools(teams: Team[]): Pool[] {
   const totalTeams = teams.length;
@@ -20,7 +21,7 @@ export function generatePools(teams: Team[]): Pool[] {
   for (let i = 0; i < poolsOf4; i++) {
     const poolTeams = shuffledTeams.slice(teamIndex, teamIndex + 4);
     pools.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       name: `Poule ${i + 1}`,
       teamIds: poolTeams.map(t => t.id),
       matches: []
@@ -32,7 +33,7 @@ export function generatePools(teams: Team[]): Pool[] {
   for (let i = 0; i < poolsOf3; i++) {
     const poolTeams = shuffledTeams.slice(teamIndex, teamIndex + 3);
     pools.push({
-      id: crypto.randomUUID(),
+      id: generateUuid(),
       name: `Poule ${poolsOf4 + i + 1}`,
       teamIds: poolTeams.map(t => t.id),
       matches: []
@@ -67,7 +68,7 @@ export function generatePoolMatches(pool: Pool, teams: Team[]): Match[] {
   for (let i = 0; i < poolTeams.length; i++) {
     for (let j = i + 1; j < poolTeams.length; j++) {
       matches.push({
-        id: crypto.randomUUID(),
+        id: generateUuid(),
         round: 1,
         court: 1,
         team1Id: poolTeams[i]!.id,

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,20 @@
+export function generateUuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20)}`;
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Summary
- provide `generateUuid()` helper to polyfill `crypto.randomUUID()`
- refactor tournament logic and components to use `generateUuid`
- add unit test for the helper

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869755d71c88324919f704bd3de408a