### PR TITLE
Add team editing capability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
     createTournament,
     addTeam,
     removeTeam,
+    updateTeam,
     generateTournamentPools,
     generateRound,
     updateMatchScore,
@@ -78,6 +79,7 @@ function App() {
             tournamentType={tournament.type}
             onAddTeam={addTeam}
             onRemoveTeam={removeTeam}
+            onUpdateTeam={updateTeam}
           />
         )}
         {activeTab === 'pools' && isPoolTournament && (

--- a/src/hooks/__tests__/updateTeam.test.ts
+++ b/src/hooks/__tests__/updateTeam.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTournament } from '../useTournament';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+describe('updateTeam', () => {
+  it('updates player names and team name', () => {
+    const makePlayer = (id: string, name: string): Player => ({
+      id,
+      name,
+      cyberImplants: [],
+      neuralScore: 100,
+      combatRating: 100,
+      hackingLevel: 1,
+      augmentationLevel: 0,
+    });
+
+    const team: Team = {
+      id: 't1',
+      name: 'Équipe 1',
+      players: [makePlayer('p1', 'Alice'), makePlayer('p2', 'Bob')],
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      performance: 0,
+      teamRating: 0,
+      synchroLevel: 0,
+    };
+
+    const initial: Tournament = {
+      id: 'tour',
+      name: 'Test',
+      type: 'doublette',
+      courts: 2,
+      teams: [team],
+      matches: [],
+      pools: [],
+      currentRound: 0,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      const newPlayers = [
+        { ...team.players[0], name: 'Charlie' },
+        { ...team.players[1], name: 'Dana' },
+      ];
+      result.current.updateTeam('t1', newPlayers, 'Team X');
+    });
+
+    const updated = result.current.tournament!.teams[0];
+    expect(updated.name).toBe('Team X');
+    expect(updated.players[0].name).toBe('Charlie');
+    expect(updated.players[1].name).toBe('Dana');
+
+    const stored = JSON.parse(localStorage.getItem('petanque-tournament')!);
+    expect(stored.teams[0].players[0].name).toBe('Charlie');
+  });
+});

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -101,6 +101,29 @@ export function useTournament() {
     saveTournament(updatedTournament);
   };
 
+  const updateTeam = (
+    teamId: string,
+    players: Player[],
+    name?: string
+  ) => {
+    if (!tournament) return;
+
+    const updatedTeams = tournament.teams.map((team, index) => {
+      if (team.id !== teamId) return team;
+
+      const newName =
+        name ??
+        (tournament.type === 'melee' || tournament.type === 'tete-a-tete'
+          ? `${index + 1} - ${players[0].name}`
+          : team.name);
+
+      return { ...team, players, name: newName };
+    });
+
+    const updatedTournament = { ...tournament, teams: updatedTeams };
+    saveTournament(updatedTournament);
+  };
+
   const generateTournamentPools = () => {
     if (!tournament) return;
 
@@ -1076,6 +1099,7 @@ export function useTournament() {
     createTournament,
     addTeam,
     removeTeam,
+    updateTeam,
     generateTournamentPools,
     generateRound,
     updateMatchScore,


### PR DESCRIPTION
## Summary
- implement `updateTeam` in useTournament
- expose updateTeam in hook and app
- allow editing teams in TeamsTab
- add EditTeamForm component
- test updating teams

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68697a3f0a608324b5c4c4602e7f02a3