### PR TITLE
Fix JSON.parse handling in useTournament

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -13,14 +13,19 @@ export function useTournament() {
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved) {
-      const parsed = JSON.parse(saved);
-      parsed.createdAt = new Date(parsed.createdAt);
-      // Ensure pools array exists for backward compatibility
-      if (!parsed.pools) {
-        parsed.pools = [];
-        parsed.poolsGenerated = false;
+      try {
+        const parsed = JSON.parse(saved);
+        parsed.createdAt = new Date(parsed.createdAt);
+        // Ensure pools array exists for backward compatibility
+        if (!parsed.pools) {
+          parsed.pools = [];
+          parsed.poolsGenerated = false;
+        }
+        setTournament(parsed);
+      } catch (e) {
+        console.warn('Failed to parse saved tournament:', e);
+        localStorage.removeItem(STORAGE_KEY);
       }
-      setTournament(parsed);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- safeguard tournament initialization against malformed localStorage
- remove corrupt saved data and log a warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68698dbb6f888324ab4898ea2c98aa9e