### PR TITLE
Remove unused Electron preload script

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -8,8 +8,7 @@ function createWindow() {
     ? path.join(process.resourcesPath, 'app.asar')
     : app.getAppPath();
 
-  // Chemins vers preload.js et index.html dans ou hors ASAR
-  const preloadPath = path.join(appPath, 'electron', 'preload.js');
+  // Chemin vers index.html dans ou hors ASAR
   const indexPath = app.isPackaged
     ? path.join(appPath, 'dist', 'index.html')
     : 'http://localhost:3000';
@@ -21,7 +20,6 @@ function createWindow() {
       ? path.join(process.resourcesPath, 'public', 'logo.ico')
       : path.join(appPath, 'public', 'logo.ico'),
     webPreferences: {
-      preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false
     }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     },
     "files": [
       "dist/**/*",
-      "electron/main.cjs",
-      "electron/preload.js"
+      "electron/main.cjs"
     ],
     "win": {
       "icon": "public/logo.ico",


### PR DESCRIPTION
## Summary
- delete unused `preload.js`
- remove preload configuration from `main.cjs`
- clean up build file list in `package.json`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68699435a4ec83249c694fd3af8509fd