### PR TITLE
Fix winner modal hidden behind pool card

### DIFF
--- a/src/components/PoolsTab.tsx
+++ b/src/components/PoolsTab.tsx
@@ -738,7 +738,7 @@ function CompactFourTeamPool({ poolTeams, poolMatches, pool, courts, onUpdateSco
     : undefined;
 
   return (
-    <div className="glass-card overflow-hidden">
+    <div className="glass-card">
       <div className="px-3 py-2 border-b border-white/20 bg-white/5">
         <h3 className="text-sm font-bold text-white">{pool.name}</h3>
       </div>
@@ -888,7 +888,7 @@ function CompactThreeTeamPool({ poolTeams, poolMatches, pool, courts, onUpdateSc
     : undefined;
 
   return (
-    <div className="glass-card overflow-hidden">
+    <div className="glass-card">
       <div className="px-3 py-2 border-b border-white/20 bg-white/5">
         <h3 className="text-sm font-bold text-white">{pool.name} (3)</h3>
       </div>


### PR DESCRIPTION
## Summary
- remove `overflow-hidden` from pool cards so the winner selection modal appears on top of pool boxes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869bf95674c8324b5911cfa7eb6c4ba