### PR TITLE
Fix empty final phase creation edge case

### DIFF
--- a/src/hooks/__tests__/finalPhasesEdge.test.ts
+++ b/src/hooks/__tests__/finalPhasesEdge.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTournament } from '../useTournament';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+describe('createEmptyFinalPhases edge case', () => {
+  it('does not create final phase matches when less than two teams qualify', () => {
+    const team = (id: string): Team => ({
+      id,
+      name: id,
+      players: [] as Player[],
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      performance: 0,
+      teamRating: 0,
+      synchroLevel: 0,
+    });
+
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette-poule',
+      courts: 2,
+      teams: [team('A'), team('B')],
+      matches: [],
+      pools: [],
+      currentRound: 0,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.generateTournamentPools();
+    });
+
+    const finals = result.current.tournament!.matches.filter(m => m.round >= 100);
+    expect(finals).toHaveLength(0);
+  });
+});

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -234,12 +234,20 @@ export function useTournament() {
   };
 
   // Nouvelle fonction pour créer les cadres vides des phases finales
-  const createEmptyFinalPhases = (totalTeams: number, courts: number, startCourt = 1) => {
+  const createEmptyFinalPhases = (
+    totalTeams: number,
+    courts: number,
+    startCourt = 1
+  ) => {
     const matches: Match[] = [];
 
     // Calculer le nombre d'équipes qualifiées attendues
     const { poolsOf4, poolsOf3 } = calculateOptimalPools(totalTeams);
     const expectedQualified = (poolsOf4 + poolsOf3) * 2;
+
+    if (expectedQualified <= 1) {
+      return matches;
+    }
 
     // Taille du tableau : puissance de deux immédiatement supérieure
     const bracketSize = 1 << Math.ceil(Math.log2(expectedQualified));


### PR DESCRIPTION
## Summary
- prevent final phase generation when fewer than two teams should qualify
- test that no finals are created for two-team tournaments

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_686b31e407f883248fc75e4e5ac6219d