### PR TITLE
Add category B finals support

### DIFF
--- a/src/hooks/__tests__/poolBye.test.ts
+++ b/src/hooks/__tests__/poolBye.test.ts
@@ -53,6 +53,7 @@ describe('pool BYE creation', () => {
         } as Match,
       ],
       pools: [{ id: 'p1', name: 'Poule 1', teamIds: ['A', 'B', 'C'], matches: [] }],
+      matchesB: [],
       currentRound: 1,
       completed: false,
       createdAt: new Date(),

--- a/src/hooks/__tests__/updateTeam.test.ts
+++ b/src/hooks/__tests__/updateTeam.test.ts
@@ -34,6 +34,7 @@ describe('updateTeam', () => {
       courts: 2,
       teams: [team],
       matches: [],
+      matchesB: [],
       pools: [],
       currentRound: 0,
       completed: false,

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -66,6 +66,7 @@ export interface Tournament {
   courts: number;
   teams: Team[];
   matches: Match[];
+  matchesB: Match[];
   pools: Pool[];
   currentRound: number;
   completed: boolean;

--- a/src/utils/__tests__/categoryB.test.ts
+++ b/src/utils/__tests__/categoryB.test.ts
@@ -1,0 +1,37 @@
+import { applyByeLogic } from '../finals';
+import { createCategoryBBracket } from '../bracket';
+import { Match } from '../../types/tournament';
+
+describe('category B finals', () => {
+  function makeMatch(id: string, team1Id = '', team2Id = ''): Match {
+    return {
+      id,
+      round: 200,
+      court: 0,
+      team1Id,
+      team2Id,
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    } as Match;
+  }
+
+  it('assigns BYE after pools conclude', () => {
+    const matches = [
+      makeMatch('m1', 't1', 't4'),
+      makeMatch('m2', 't2', 't5'),
+      makeMatch('m3', 't3'),
+      makeMatch('m4', 't6'),
+    ];
+    const result = applyByeLogic(matches, 6, 6, 0);
+    const byeMatches = result.filter(m => m.isBye);
+    expect(byeMatches).toHaveLength(2);
+  });
+
+  it('creates bracket of correct size for nine teams', () => {
+    const matches = createCategoryBBracket(9);
+    const firstRound = matches.filter(m => m.round === 200);
+    expect(firstRound).toHaveLength(8);
+  });
+});

--- a/src/utils/bracket.ts
+++ b/src/utils/bracket.ts
@@ -107,3 +107,34 @@ export function createKnockoutBracket(teams: Team[], startingRound = 1): Match[]
 
   return matches;
 }
+
+// Generate empty bracket for Category B finals starting at round >=200
+export function createCategoryBBracket(teamCount: number, startingRound = 200): Match[] {
+  const matches: Match[] = [];
+  if (teamCount <= 1) return matches;
+
+  const bracketSize = 1 << Math.ceil(Math.log2(teamCount));
+  let current = bracketSize;
+  let round = startingRound;
+
+  while (current > 1) {
+    const matchesInRound = Math.floor(current / 2);
+    for (let i = 0; i < matchesInRound; i++) {
+      matches.push({
+        id: generateUuid(),
+        round,
+        court: 0,
+        team1Id: '',
+        team2Id: '',
+        completed: false,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      });
+    }
+    current = matchesInRound + (current % 2);
+    round += 1;
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- extend tournament model with `matchesB`
- build category B final brackets and propagate winners
- toggle display between category A/B finals
- add new tests for category B logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b31e0d7ac8324bba78e76b6996416