### PR TITLE
Show court availability for cat B bracket

### DIFF
--- a/src/components/PoolsTab.tsx
+++ b/src/components/PoolsTab.tsx
@@ -269,7 +269,10 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
             ))}
           </div>
 
-          <CourtAvailability courts={tournament.courts} matches={tournament.matches} />
+          <CourtAvailability
+            courts={tournament.courts}
+            matches={showCatB ? tournament.matchesB : tournament.matches}
+          />
 
           {/* Phases finales - TOUJOURS affichées avec remplissage progressif */}
           <div className="flex justify-end mb-2">
@@ -304,16 +307,22 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
 
           {/* Phases finales - affichage conditionnel */}
           {showCategoryB ? (
-            <FinalPhases
-              qualifiedTeams={qualifiedTeams}
-              tournament={tournament}
-              matches={tournament.matchesB}
-              onUpdateScore={onUpdateScore}
-              onUpdateCourt={onUpdateCourt}
-              totalTeams={teams.length}
-              title="Catégorie B"
-              roundOffset={200}
-            />
+            <>
+              <CourtAvailability
+                courts={tournament.courts}
+                matches={tournament.matchesB}
+              />
+              <FinalPhases
+                qualifiedTeams={qualifiedTeams}
+                tournament={tournament}
+                matches={tournament.matchesB}
+                onUpdateScore={onUpdateScore}
+                onUpdateCourt={onUpdateCourt}
+                totalTeams={teams.length}
+                title="Catégorie B"
+                roundOffset={200}
+              />
+            </>
           ) : (
             <FinalPhases
               qualifiedTeams={qualifiedTeams}


### PR DESCRIPTION
## Summary
- show available courts for the selected bracket (A/B)
- display court availability above the Category B finals section

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686bcdd573d48324b2cabec227b7c127