### PR TITLE
Fix BYE allocation in category B

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -813,20 +813,39 @@ export function useTournament() {
     });
 
     const firstRound = matchesB.filter(m => m.round === 200);
-    const used = new Set<string>();
-    firstRound.forEach(m => { if (m.team1Id) used.add(m.team1Id); if (m.team2Id) used.add(m.team2Id); });
-    const positions: { matchIndex: number; position: 'team1' | 'team2' }[] = [];
-    firstRound.forEach((m, idx) => {
-      if (!m.team1Id) positions.push({ matchIndex: idx, position: 'team1' });
-      if (!m.team2Id) positions.push({ matchIndex: idx, position: 'team2' });
-    });
-    const newTeams = bottomTeams.filter(t => !used.has(t.id));
-    newTeams.forEach(team => {
-      if (positions.length === 0) return;
-      const pos = positions.shift()!;
-      const match = firstRound[pos.matchIndex];
-      firstRound[pos.matchIndex] = { ...match, [pos.position + 'Id']: team.id } as Match;
-    });
+    const bracketSize = 1 << Math.ceil(Math.log2(bottomTeams.length));
+    const byesNeeded = bracketSize - bottomTeams.length;
+
+    const sortedTeams = [...bottomTeams];
+    let teamIdx = 0;
+
+    for (let i = 0; i < firstRound.length; i++) {
+      const match = firstRound[i];
+      if (teamIdx < byesNeeded) {
+        const team = sortedTeams[teamIdx++];
+        firstRound[i] = {
+          ...match,
+          team1Id: team.id,
+          team2Id: team.id,
+          team1Score: 13,
+          team2Score: 0,
+          completed: true,
+          isBye: true,
+        } as Match;
+      } else {
+        const t1 = sortedTeams[teamIdx++];
+        const t2 = sortedTeams[teamIdx++];
+        firstRound[i] = {
+          ...match,
+          team1Id: t1?.id || '',
+          team2Id: t2?.id || '',
+          team1Score: undefined,
+          team2Score: undefined,
+          completed: false,
+          isBye: false,
+        } as Match;
+      }
+    }
 
     const pending = t.matches.filter(m => m.poolId && !m.completed).length;
     const withByes = applyByeLogic(firstRound, bottomTeams.length, bottomCount, pending);

--- a/src/utils/__tests__/categoryB.test.ts
+++ b/src/utils/__tests__/categoryB.test.ts
@@ -34,4 +34,58 @@ describe('category B finals', () => {
     const firstRound = matches.filter(m => m.round === 200);
     expect(firstRound).toHaveLength(8);
   });
+
+  it('creates 15 BYEs for the 35 team scenario', () => {
+    function makeTeam(id: string) {
+      return {
+        id,
+        name: id,
+        players: [],
+        wins: 0,
+        losses: 0,
+        pointsFor: 0,
+        pointsAgainst: 0,
+        performance: 0,
+        teamRating: 0,
+        synchroLevel: 0,
+      } as const;
+    }
+
+    const teams = Array.from({ length: 17 }).map((_, i) => makeTeam(`t${i + 1}`));
+    const bracket = createCategoryBBracket(teams.length);
+    const firstRound = bracket.filter(m => m.round === 200);
+
+    const bracketSize = 1 << Math.ceil(Math.log2(teams.length));
+    const byesNeeded = bracketSize - teams.length;
+
+    let teamIdx = 0;
+    for (let i = 0; i < firstRound.length; i++) {
+      if (i < byesNeeded) {
+        const t = teams[teamIdx++];
+        firstRound[i] = {
+          ...firstRound[i],
+          team1Id: t.id,
+          team2Id: t.id,
+          completed: true,
+          isBye: true,
+        } as Match;
+      } else {
+        const t1 = teams[teamIdx++];
+        const t2 = teams[teamIdx++];
+        firstRound[i] = {
+          ...firstRound[i],
+          team1Id: t1.id,
+          team2Id: t2.id,
+          completed: false,
+          isBye: false,
+        } as Match;
+      }
+    }
+
+    const placed = applyByeLogic(firstRound, teams.length, teams.length, 0);
+    const byeMatches = placed.filter(m => m.isBye);
+    expect(placed).toHaveLength(16);
+    expect(byeMatches).toHaveLength(15);
+    expect(placed.filter(m => !m.isBye)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary
- handle BYE placement when bottom bracket has fewer teams than slots
- test BYE distribution for a 35-team tournament

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bef2abecc8324b13a5081be175aba