### PR TITLE
Avoid populating category B early

### DIFF
--- a/src/hooks/finalsLogic.ts
+++ b/src/hooks/finalsLogic.ts
@@ -231,6 +231,10 @@ export function updateCategoryBPhases(t: Tournament): Tournament {
   const { poolsOf4, poolsOf3 } = calculateOptimalPools(t.teams.length);
   const expectedQualified = (poolsOf4 + poolsOf3) * 2;
   const bottomCount = t.teams.length - expectedQualified;
+  // If no team has qualified yet, don't populate category B
+  if (bottomTeams.length === t.teams.length) {
+    return t;
+  }
   if (bottomCount <= 1) return t;
 
   let matchesB = t.matchesB;


### PR DESCRIPTION
## Summary
- ensure updateCategoryBPhases returns early when no teams have qualified yet

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c204752b483248ea2922a1ac78737