### PR TITLE
Handle empty finals matches as BYE

### DIFF
--- a/src/utils/__tests__/finals.test.ts
+++ b/src/utils/__tests__/finals.test.ts
@@ -121,4 +121,19 @@ describe('applyByeLogic', () => {
     const byeMatches = withByes.filter(m => m.isBye);
     expect(byeMatches).toHaveLength(4);
   });
+
+  it('removes empty matches when BYEs can fill remaining slots', () => {
+    const matches = [
+      makeMatch('m1', 't1', 't2'),
+      makeMatch('m2'),
+      makeMatch('m3', 't3'),
+      makeMatch('m4'),
+    ];
+
+    const result = applyByeLogic(matches, 3, 6, 0);
+    const empty = result.filter(m => !m.team1Id && !m.team2Id && !m.isBye);
+    expect(empty).toHaveLength(0);
+    const byeMatches = result.filter(m => m.isBye);
+    expect(byeMatches).toHaveLength(3);
+  });
 });

--- a/src/utils/finals.ts
+++ b/src/utils/finals.ts
@@ -13,17 +13,30 @@ export function applyByeLogic(matches: Match[], qualifiedCount: number, expected
 
   if (pendingPoolMatches === 0 && qualifiedCount + remainingSlots >= expectedQualified) {
     return matches.map(match => {
-      if (!match.completed && ((match.team1Id && !match.team2Id) || (!match.team1Id && match.team2Id))) {
-        const solo = match.team1Id || match.team2Id || '';
-        return {
-          ...match,
-          team1Id: solo,
-          team2Id: solo,
-          team1Score: 13,
-          team2Score: 0,
-          completed: true,
-          isBye: true,
-        };
+      if (!match.completed) {
+        if ((match.team1Id && !match.team2Id) || (!match.team1Id && match.team2Id)) {
+          const solo = match.team1Id || match.team2Id || '';
+          return {
+            ...match,
+            team1Id: solo,
+            team2Id: solo,
+            team1Score: 13,
+            team2Score: 0,
+            completed: true,
+            isBye: true,
+          };
+        }
+        if (!match.team1Id && !match.team2Id) {
+          return {
+            ...match,
+            team1Id: '',
+            team2Id: '',
+            team1Score: 13,
+            team2Score: 0,
+            completed: true,
+            isBye: true,
+          };
+        }
       }
       return match;
     });


### PR DESCRIPTION
## Summary
- treat matches without teams as BYEs when enough empty slots exist
- ensure empty finals matches disappear after BYE logic

## Testing
- `npm ci --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c4a03e83c8324a202b1768e91ec35