### PR TITLE
Fix category B bracket size calc

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -114,8 +114,8 @@ export function useTournament() {
     });
 
     const firstRound = matchesB.filter(m => m.round === 200);
-    const bracketSize = 1 << Math.ceil(Math.log2(bottomTeams.length));
-    const byesNeeded = bracketSize - bottomTeams.length;
+    const bracketSize = 1 << Math.ceil(Math.log2(bottomCount));
+    const byesNeeded = bracketSize - bottomCount;
 
     const sortedTeams = [...bottomTeams];
     let teamIdx = 0;


### PR DESCRIPTION
## Summary
- compute `bracketSize` and `byesNeeded` using `bottomCount`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c4a01a51c8324bac150a7d85bc15e