### PR TITLE
Improve category B bracket creation

### DIFF
--- a/src/hooks/__tests__/categoryBRecompute.test.ts
+++ b/src/hooks/__tests__/categoryBRecompute.test.ts
@@ -1,0 +1,128 @@
+import { updateCategoryBPhases } from '../finalsLogic';
+import { Tournament, Team, Player, Pool, Match } from '../../types/tournament';
+
+describe('Category B recompute when bottom count changes', () => {
+  it('rebuilds first round to correct BYE count', () => {
+    const makeTeam = (id: string): Team => ({
+      id,
+      name: id,
+      players: [] as Player[],
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      performance: 0,
+      teamRating: 0,
+      synchroLevel: 0,
+    });
+
+    const teams: Team[] = Array.from({ length: 35 }, (_, i) => makeTeam(`T${i + 1}`));
+    const pools: Pool[] = [];
+
+    for (let i = 0; i < 8; i++) {
+      const ids = teams.slice(i * 4, i * 4 + 4).map(t => t.id);
+      pools.push({ id: `p${i + 1}`, name: `Poule ${i + 1}`, teamIds: ids, matches: [] });
+    }
+    pools.push({ id: 'p9', name: 'Poule 9', teamIds: teams.slice(32).map(t => t.id), matches: [] });
+
+    pools.forEach(pool => {
+      pool.teamIds.forEach(id => {
+        const t = teams.find(tm => tm.id === id)!;
+        t.poolId = pool.id;
+      });
+    });
+
+    const matches: Match[] = [];
+    let mId = 0;
+    pools.forEach((pool, idx) => {
+      const [t1, t2, t3] = pool.teamIds;
+      // give two BYE wins to first team in each pool
+      [t1].forEach(id => {
+        for (let i = 0; i < 2; i++) {
+          matches.push({
+            id: `m${mId++}`,
+            round: 1,
+            court: 0,
+            team1Id: id,
+            team2Id: id,
+            team1Score: 13,
+            team2Score: 0,
+            completed: true,
+            isBye: true,
+            poolId: pool.id,
+            battleIntensity: 0,
+            hackingAttempts: 0,
+          } as Match);
+        }
+      });
+      // for first eight pools give wins to second team as well
+      if (idx < 8) {
+        [t2].forEach(id => {
+          for (let i = 0; i < 2; i++) {
+            matches.push({
+              id: `m${mId++}`,
+              round: 1,
+              court: 0,
+              team1Id: id,
+              team2Id: id,
+              team1Score: 13,
+              team2Score: 0,
+              completed: true,
+              isBye: true,
+              poolId: pool.id,
+              battleIntensity: 0,
+              hackingAttempts: 0,
+            } as Match);
+          }
+        });
+      }
+    });
+
+    const tournament: Tournament = {
+      id: 'tour',
+      name: 'Test',
+      type: 'doublette-poule',
+      courts: 8,
+      teams,
+      matches,
+      matchesB: [],
+      pools,
+      currentRound: 1,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: true,
+    };
+
+    // initial call with only 17 qualifiers (last pool second team missing)
+    let interim = updateCategoryBPhases(tournament);
+
+    // now add wins for T34 to reach expected 18 qualifiers
+    ['T34'].forEach(id => {
+      for (let i = 0; i < 2; i++) {
+        interim.matches.push({
+          id: `extra${mId++}`,
+          round: 1,
+          court: 0,
+          team1Id: id,
+          team2Id: id,
+          team1Score: 13,
+          team2Score: 0,
+          completed: true,
+          isBye: true,
+          poolId: 'p9',
+          battleIntensity: 0,
+          hackingAttempts: 0,
+        } as Match);
+      }
+    });
+
+    const updated = updateCategoryBPhases(interim);
+    const firstRound = updated.matchesB.filter(m => m.round === 200);
+    const byeMatches = firstRound.filter(m => m.isBye);
+
+    expect(firstRound).toHaveLength(16);
+    expect(byeMatches).toHaveLength(15);
+  });
+});

--- a/src/hooks/finalsLogic.ts
+++ b/src/hooks/finalsLogic.ts
@@ -238,8 +238,14 @@ export function updateCategoryBPhases(t: Tournament): Tournament {
   if (bottomCount <= 1) return t;
 
   let matchesB = t.matchesB;
-  if (matchesB.length === 0) {
-    matchesB = createEmptyFinalPhasesB(t.teams.length, t.courts, t.pools.length * 2 + 1);
+  const rebuildBracket =
+    matchesB.length === 0 || bottomTeams.length !== bottomCount;
+  if (rebuildBracket) {
+    matchesB = createEmptyFinalPhasesB(
+      t.teams.length,
+      t.courts,
+      t.pools.length * 2 + 1,
+    );
   }
 
   matchesB = matchesB.map(match => {
@@ -269,25 +275,62 @@ export function updateCategoryBPhases(t: Tournament): Tournament {
   });
 
   const firstRound = matchesB.filter(m => m.round === 200);
-  const used = new Set<string>();
-  firstRound.forEach(m => {
-    if (m.team1Id) used.add(m.team1Id);
-    if (m.team2Id) used.add(m.team2Id);
-  });
-  const positions: { matchIndex: number; position: 'team1' | 'team2' }[] = [];
-  firstRound.forEach((m, idx) => {
-    if (!m.team1Id) positions.push({ matchIndex: idx, position: 'team1' });
-  });
-  firstRound.forEach((m, idx) => {
-    if (!m.team2Id) positions.push({ matchIndex: idx, position: 'team2' });
-  });
-  const newTeams = bottomTeams.filter(t => !used.has(t.id));
-  newTeams.forEach(team => {
-    if (positions.length === 0) return;
-    const pos = positions.shift()!;
-    const match = firstRound[pos.matchIndex];
-    firstRound[pos.matchIndex] = { ...match, [pos.position + 'Id']: team.id } as Match;
-  });
+  if (rebuildBracket) {
+    const bracketSize = 1 << Math.ceil(Math.log2(bottomCount));
+    const byesNeeded = bracketSize - bottomCount;
+    const sorted = [...bottomTeams];
+    let teamIdx = 0;
+    for (let i = 0; i < firstRound.length; i++) {
+      const match = firstRound[i];
+      if (teamIdx < byesNeeded) {
+        const team = sorted[teamIdx++];
+        firstRound[i] = {
+          ...match,
+          team1Id: team?.id || '',
+          team2Id: team?.id || '',
+          team1Score: 13,
+          team2Score: 0,
+          completed: true,
+          isBye: true,
+        } as Match;
+      } else {
+        const t1 = sorted[teamIdx++];
+        const t2 = sorted[teamIdx++];
+        firstRound[i] = {
+          ...match,
+          team1Id: t1?.id || '',
+          team2Id: t2?.id || '',
+          team1Score: undefined,
+          team2Score: undefined,
+          completed: false,
+          isBye: false,
+        } as Match;
+      }
+    }
+  } else {
+    const used = new Set<string>();
+    firstRound.forEach(m => {
+      if (m.team1Id) used.add(m.team1Id);
+      if (m.team2Id) used.add(m.team2Id);
+    });
+    const positions: { matchIndex: number; position: 'team1' | 'team2' }[] = [];
+    firstRound.forEach((m, idx) => {
+      if (!m.team1Id) positions.push({ matchIndex: idx, position: 'team1' });
+    });
+    firstRound.forEach((m, idx) => {
+      if (!m.team2Id) positions.push({ matchIndex: idx, position: 'team2' });
+    });
+    const newTeams = bottomTeams.filter(bt => !used.has(bt.id));
+    newTeams.forEach(team => {
+      if (positions.length === 0) return;
+      const pos = positions.shift()!;
+      const match = firstRound[pos.matchIndex];
+      firstRound[pos.matchIndex] = {
+        ...match,
+        [pos.position + 'Id']: team.id,
+      } as Match;
+    });
+  }
 
   const pending = t.matches.filter(m => m.poolId && !m.completed).length;
   const withByes = applyByeLogic(firstRound, bottomTeams.length, bottomCount, pending);


### PR DESCRIPTION
## Summary
- recompute Category B matches when pool results change
- fill first-round pairings sequentially and apply BYEs
- test recomputation of Category B bracket

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c52a356888324a700bb1a2404cbef