### PR TITLE
Disable auto assignment of finals courts

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -239,6 +239,9 @@ export function MatchesTab({
                                 onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
                                 className="glass-select text-sm border-0 font-medium"
                               >
+                                {match.court === 0 && (
+                                  <option value={0} className="bg-slate-800">Choisir</option>
+                                )}
                                 {Array.from({ length: courts }, (_, i) => i + 1).map(court => (
                                   <option key={court} value={court} className="bg-slate-800">{court}</option>
                                 ))}

--- a/src/hooks/finalsLogic.ts
+++ b/src/hooks/finalsLogic.ts
@@ -12,7 +12,6 @@ export function createEmptyFinalPhases(totalTeams: number, courts: number, start
   const bracketSize = 1 << Math.ceil(Math.log2(expectedQualified));
   let currentTeamCount = bracketSize;
   let round = 100;
-  let courtIndex = startCourt;
 
   while (currentTeamCount > 1) {
     const matchesInRound = Math.floor(currentTeamCount / 2);
@@ -20,7 +19,7 @@ export function createEmptyFinalPhases(totalTeams: number, courts: number, start
       matches.push({
         id: generateUuid(),
         round,
-        court: courtIndex,
+        court: 0,
         team1Id: '',
         team2Id: '',
         completed: false,
@@ -28,7 +27,6 @@ export function createEmptyFinalPhases(totalTeams: number, courts: number, start
         battleIntensity: 0,
         hackingAttempts: 0,
       });
-      courtIndex = (courtIndex % courts) + 1;
     }
     currentTeamCount = matchesInRound + (currentTeamCount % 2);
     round++;
@@ -47,7 +45,7 @@ export function createEmptyFinalPhasesB(totalTeams: number, courts: number, star
   const bracketSize = 1 << Math.ceil(Math.log2(bottomTeams));
   let currentTeamCount = bracketSize;
   let round = 200;
-  let courtIndex = startCourt;
+  // Courts for Category B finals are chosen manually
 
   while (currentTeamCount > 1) {
     const matchesInRound = Math.floor(currentTeamCount / 2);
@@ -55,7 +53,7 @@ export function createEmptyFinalPhasesB(totalTeams: number, courts: number, star
       matches.push({
         id: generateUuid(),
         round,
-        court: courtIndex,
+        court: 0,
         team1Id: '',
         team2Id: '',
         completed: false,
@@ -63,7 +61,6 @@ export function createEmptyFinalPhasesB(totalTeams: number, courts: number, star
         battleIntensity: 0,
         hackingAttempts: 0,
       });
-      courtIndex = (courtIndex % courts) + 1;
     }
     currentTeamCount = matchesInRound + (currentTeamCount % 2);
     round++;


### PR DESCRIPTION
## Summary
- stop setting court numbers when creating Category A and B brackets
- allow manual court selection by showing a placeholder option when no court is assigned

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c58aa1fc88324a1e90b8cfc4f8fcf