### PR TITLE
Fix court availability display for Catégorie A finals

### DIFF
--- a/src/components/PoolsTab.tsx
+++ b/src/components/PoolsTab.tsx
@@ -289,16 +289,22 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
               />
             </>
           ) : (
-            <FinalPhases
-              qualifiedTeams={qualifiedTeams}
-              tournament={tournament}
-              matches={tournament.matches}
-              onUpdateScore={onUpdateScore}
-              onUpdateCourt={onUpdateCourt}
-              totalTeams={teams.length}
-              title="Catégorie A"
-              roundOffset={100}
-            />
+            <>
+              <CourtAvailability
+                courts={tournament.courts}
+                matches={tournament.matches}
+              />
+              <FinalPhases
+                qualifiedTeams={qualifiedTeams}
+                tournament={tournament}
+                matches={tournament.matches}
+                onUpdateScore={onUpdateScore}
+                onUpdateCourt={onUpdateCourt}
+                totalTeams={teams.length}
+                title="Catégorie A"
+                roundOffset={100}
+              />
+            </>
           )}
 
           {/* Statistiques des poules */}


### PR DESCRIPTION
## Summary
- show court availability for Catégorie A finals just like for Catégorie B

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5cf56ad883249d0e60d391d31e46