### PR TITLE
Handle melee matchup leftovers

### DIFF
--- a/src/utils/__tests__/meleeMatchmaking.test.ts
+++ b/src/utils/__tests__/meleeMatchmaking.test.ts
@@ -1,0 +1,69 @@
+import { generateMatches } from '../matchmaking';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+function makePlayer(id: string): Player {
+  return {
+    id,
+    name: `Player ${id}`,
+    cyberImplants: [],
+    neuralScore: 0,
+    combatRating: 0,
+    hackingLevel: 0,
+    augmentationLevel: 0,
+  };
+}
+
+function makeTeam(id: string): Team {
+  return {
+    id,
+    name: id,
+    players: [makePlayer(id)],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  };
+}
+
+describe('generateMeleeMatches edge cases', () => {
+  function baseTournament(teams: Team[]): Tournament {
+    return {
+      id: 't',
+      name: 'Test',
+      type: 'melee',
+      courts: 1,
+      teams,
+      matches: [],
+      matchesB: [],
+      pools: [],
+      currentRound: 0,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+  }
+
+  it('pairs two remaining players against each other', () => {
+    const teams = [makeTeam('A'), makeTeam('B')];
+    const tournament = baseTournament(teams);
+    const matches = generateMatches(tournament);
+    expect(matches).toHaveLength(1);
+    const ids = [matches[0].team1Id, matches[0].team2Id].sort();
+    expect(ids).toEqual(['A', 'B']);
+  });
+
+  it('creates a bye for a final triplette', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C')];
+    const tournament = baseTournament(teams);
+    const matches = generateMatches(tournament);
+    expect(matches).toHaveLength(1);
+    const match = matches[0];
+    expect(match.isBye).toBe(true);
+    expect(match.team1Ids?.sort()).toEqual(['A', 'B', 'C'].sort());
+  });
+});

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -332,19 +332,39 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
 
   if (groups.length === 1) {
     const teamIds = groups.shift()!;
-    matchesResult.push({
-      id: generateUuid(),
-      round,
-      court: courtIndex,
-      team1Id: teamIds[0],
-      team2Id: teamIds[0],
-      team1Ids: teamIds,
-      team2Ids: teamIds,
-      completed: false,
-      isBye: false,
-      battleIntensity: 0,
-      hackingAttempts: 0,
-    });
+
+    if (teamIds.length === 2) {
+      matchesResult.push({
+        id: generateUuid(),
+        round,
+        court: courtIndex,
+        team1Id: teamIds[0],
+        team2Id: teamIds[1],
+        team1Ids: [teamIds[0]],
+        team2Ids: [teamIds[1]],
+        completed: false,
+        isBye: false,
+        battleIntensity: Math.floor(Math.random() * 100) + 50,
+        hackingAttempts: 0,
+      });
+    } else if (teamIds.length === 3) {
+      matchesResult.push({
+        id: generateUuid(),
+        round,
+        court: courtIndex,
+        team1Id: teamIds[0],
+        team2Id: teamIds[0],
+        team1Ids: teamIds,
+        team2Ids: teamIds,
+        team1Score: 13,
+        team2Score: 0,
+        completed: true,
+        isBye: true,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      });
+    }
+
     courtIndex++;
   }
 


### PR DESCRIPTION
## Summary
- improve melee matchmaking logic for last unpaired group
- add tests for 2- and 3-player melee tournaments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c612a40d48324bb07c2c86fffb93a