### PR TITLE
Add disabled state styling for glass buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,11 @@
     box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
     transform: translateY(-1px);
   }
+
+  .glass-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
   
   .glass-button-secondary {
     background: rgba(255, 255, 255, 0.2);
@@ -77,6 +82,11 @@
     background: rgba(255, 255, 255, 0.3);
     border: 1px solid rgba(255, 255, 255, 0.4);
     transform: translateY(-1px);
+  }
+
+  .glass-button-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
   
   .glass-input {


### PR DESCRIPTION
## Summary
- style disabled `.glass-button` with reduced opacity and a not-allowed cursor
- apply the same styling to `.glass-button-secondary`

## Testing
- `npm run lint` *(fails: cannot find ESLint config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c64c8e20c83249cd2dcab3edebd69