### PR TITLE
Update pool round generation

### DIFF
--- a/src/hooks/__tests__/generateRoundIncrement.test.ts
+++ b/src/hooks/__tests__/generateRoundIncrement.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTournament } from '../useTournament';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+describe('generateRound increments currentRound', () => {
+  it('increments currentRound for pool tournaments', () => {
+    const makeTeam = (id: string): Team => ({
+      id,
+      name: id,
+      players: [] as Player[],
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      performance: 0,
+      teamRating: 0,
+      synchroLevel: 0,
+    });
+
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette-poule',
+      courts: 2,
+      teams: [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')],
+      matches: [],
+      matchesB: [],
+      pools: [],
+      currentRound: 0,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.generateTournamentPools();
+    });
+
+    expect(result.current.tournament!.currentRound).toBe(1);
+
+    act(() => {
+      result.current.generateRound();
+    });
+
+    expect(result.current.tournament!.currentRound).toBe(2);
+  });
+});

--- a/src/hooks/poolManagement.ts
+++ b/src/hooks/poolManagement.ts
@@ -413,6 +413,6 @@ export function generateRound(tournament: Tournament): Tournament {
 
   const allMatches = generateNextPoolMatches(tournament);
 
-  return { ...tournament, matches: allMatches };
+  return { ...tournament, matches: allMatches, currentRound: tournament.currentRound + 1 };
 }
 


### PR DESCRIPTION
## Summary
- increment tournament round when generating a pool round
- test that generateRound increments the round number for pool tournaments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c6cdfe0e883249b7ecf9ed31cc836