### PR TITLE
Add localStorage cleanup in tests

### DIFF
--- a/src/hooks/__tests__/barrage.test.ts
+++ b/src/hooks/__tests__/barrage.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('barrage generation', () => {
   it('creates round 3 match when two teams have one win each', () => {
     const team = (id: string): Team => ({

--- a/src/hooks/__tests__/barragePool4.test.ts
+++ b/src/hooks/__tests__/barragePool4.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('barrage generation in pool of four', () => {
   it('creates round 3 match when two teams have one win each', () => {
     const team = (id: string): Team => ({

--- a/src/hooks/__tests__/categoryBBye.test.ts
+++ b/src/hooks/__tests__/categoryBBye.test.ts
@@ -1,6 +1,10 @@
 import { updateCategoryBPhases } from '../finalsLogic';
 import { Tournament, Team, Player, Pool, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('Category B BYE generation for 35 teams', () => {
   it('creates 15 BYE matches automatically', () => {
     const makeTeam = (id: string): Team => ({

--- a/src/hooks/__tests__/categoryBRecompute.test.ts
+++ b/src/hooks/__tests__/categoryBRecompute.test.ts
@@ -1,6 +1,10 @@
 import { updateCategoryBPhases } from '../finalsLogic';
 import { Tournament, Team, Player, Pool, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('Category B recompute when bottom count changes', () => {
   it('rebuilds first round to correct BYE count', () => {
     const makeTeam = (id: string): Team => ({

--- a/src/hooks/__tests__/finalCourts.test.ts
+++ b/src/hooks/__tests__/finalCourts.test.ts
@@ -1,5 +1,9 @@
 import { createEmptyFinalPhases, createEmptyFinalPhasesB } from '../finalsLogic';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('final phase court assignment', () => {
   it('assigns sequential courts in category A finals', () => {
     const start = 5;

--- a/src/hooks/__tests__/finalPhasesEdge.test.ts
+++ b/src/hooks/__tests__/finalPhasesEdge.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('createEmptyFinalPhases edge case', () => {
   it('does not create final phase matches when less than two teams qualify', () => {
     const team = (id: string): Team => ({

--- a/src/hooks/__tests__/generateRoundByes.test.ts
+++ b/src/hooks/__tests__/generateRoundByes.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player, Pool, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('generateRound BYE creation', () => {
   it('creates BYE matches for bottom bracket', () => {
     const makeTeam = (id: string): Team => ({

--- a/src/hooks/__tests__/generateRoundCategoryBBye.test.ts
+++ b/src/hooks/__tests__/generateRoundCategoryBBye.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player, Pool, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('generateRound Category B BYE creation for 35 teams', () => {
   it('creates 16 matches with 15 BYEs in first round', () => {
     const makeTeam = (id: string): Team => ({

--- a/src/hooks/__tests__/generateRoundIncrement.test.ts
+++ b/src/hooks/__tests__/generateRoundIncrement.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('generateRound increments currentRound', () => {
   it('increments currentRound for pool tournaments', () => {
     const makeTeam = (id: string): Team => ({

--- a/src/hooks/__tests__/poolBye.test.ts
+++ b/src/hooks/__tests__/poolBye.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player, Match } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('pool BYE creation', () => {
   it('creates BYE for first match loser in pool of three', () => {
     const teamTemplate = (id: string): Team => ({

--- a/src/hooks/__tests__/updateTeam.test.ts
+++ b/src/hooks/__tests__/updateTeam.test.ts
@@ -2,6 +2,10 @@ import { renderHook, act } from '@testing-library/react';
 import { useTournament } from '../useTournament';
 import { Tournament, Team, Player } from '../../types/tournament';
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('updateTeam', () => {
   it('updates player names and team name', () => {
     const makePlayer = (id: string, name: string): Player => ({


### PR DESCRIPTION
## Summary
- ensure a clean slate for hook tests by clearing `localStorage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c74b88b2483248ef01e8dc67e8315