### PR TITLE
Display player names with hyphen

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -43,7 +43,7 @@ export function MatchesTab({
     if (!team) return '';
     return team.players
       .map(player => (player.label ? `[${player.label}] ${player.name}` : player.name))
-      .join(', ');
+      .join(' - ');
   };
 
   const getGroupLabel = (ids: string[]) => {


### PR DESCRIPTION
## Summary
- show players with a hyphen between names in the matches list and print view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c7ff1af008324bbb95a0f7e5eabbe