### PR TITLE
Adjust match table column widths

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -205,22 +205,22 @@ export function MatchesTab({
               </button>
             </div>
             <div className="overflow-x-auto">
-              <table className="glass-table w-full">
+              <table className="glass-table w-full table-fixed">
                 <thead>
                   <tr>
-                    <th className="px-6 py-4 text-left font-bold tracking-wider">
+                    <th className="w-1/12 px-2 py-4 text-left font-bold tracking-wider">
                       Terrain
                     </th>
-                    <th className="px-6 py-4 text-center font-bold tracking-wider">
+                    <th className="w-4/12 px-4 py-4 text-center font-bold tracking-wider">
                       {isSolo ? 'Joueur' : 'Équipe'}
                     </th>
-                    <th className="px-4 py-4 text-center font-bold tracking-wider">
+                    <th className="w-2/12 px-2 py-4 text-center font-bold tracking-wider">
                       Score
                     </th>
-                    <th className="px-6 py-4 text-center font-bold tracking-wider">
+                    <th className="w-4/12 px-4 py-4 text-center font-bold tracking-wider">
                       {isSolo ? 'Joueur' : 'Équipe'}
                     </th>
-                    <th className="px-4 py-4 text-center font-bold tracking-wider">
+                    <th className="w-1/12 px-2 py-4 text-center font-bold tracking-wider">
                       Actions
                     </th>
                   </tr>
@@ -228,7 +228,7 @@ export function MatchesTab({
                 <tbody>
                   {groupedMatches[round].map((match) => (
                     <tr key={match.id} className="hover:bg-white/5 transition-colors">
-                      <td className="px-6 py-4 whitespace-nowrap">
+                      <td className="w-1/12 px-2 py-4 whitespace-nowrap">
                         {match.isBye ? (
                           <span className="text-white/50">-</span>
                         ) : (
@@ -238,7 +238,7 @@ export function MatchesTab({
                               <select
                                 value={match.court}
                                 onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
-                                className="glass-select text-sm border-0 font-medium"
+                                className="glass-select w-16 text-sm border-0 font-medium"
                               >
                                 <option value={match.court}>{`Libre ${match.court - courts}`}</option>
                                 {Array.from({ length: courts }, (_, i) => i + 1).map(court => (
@@ -249,7 +249,7 @@ export function MatchesTab({
                               <select
                                 value={match.court}
                                 onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
-                                className="glass-select text-sm border-0 font-medium"
+                                className="glass-select w-16 text-sm border-0 font-medium"
                               >
                                 {match.court === 0 && (
                                   <option value={0} className="bg-slate-800">Choisir</option>
@@ -262,7 +262,7 @@ export function MatchesTab({
                           </div>
                         )}
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-center">
+                      <td className="w-4/12 px-4 py-4 whitespace-nowrap text-center">
                           {match.team1Ids ? (
                             <span className="font-bold text-white">{getGroupLabel(match.team1Ids)}</span>
                           ) : (
@@ -276,7 +276,7 @@ export function MatchesTab({
                             </>
                           )}
                       </td>
-                      <td className="px-4 py-4 whitespace-nowrap text-center">
+                      <td className="w-2/12 px-2 py-4 whitespace-nowrap text-center">
                         {editingMatch === match.id ? (
                           <div className="flex items-center justify-center space-x-2">
                             <input
@@ -303,7 +303,7 @@ export function MatchesTab({
                           </span>
                         )}
                       </td>
-                      <td className="pl-8 pr-6 py-4 whitespace-nowrap text-center">
+                      <td className="w-4/12 px-4 py-4 whitespace-nowrap text-center">
                           {match.isBye ? (
                             <span className="text-white/50 italic font-bold">BYE</span>
                           ) : match.team2Ids ? (
@@ -319,7 +319,7 @@ export function MatchesTab({
                             </>
                           )}
                       </td>
-                      <td className="px-4 py-4 whitespace-nowrap text-center">
+                      <td className="w-1/12 px-2 py-4 whitespace-nowrap text-center">
                         {!match.isBye && (
                           <div className="flex justify-center space-x-2">
                             {editingMatch === match.id ? (

--- a/src/hooks/__tests__/categoryBRecompute.test.ts
+++ b/src/hooks/__tests__/categoryBRecompute.test.ts
@@ -39,7 +39,7 @@ describe('Category B recompute when bottom count changes', () => {
     const matches: Match[] = [];
     let mId = 0;
     pools.forEach((pool, idx) => {
-      const [t1, t2, t3] = pool.teamIds;
+      const [t1, t2] = pool.teamIds;
       // give two BYE wins to first team in each pool
       [t1].forEach(id => {
         for (let i = 0; i < 2; i++) {
@@ -100,7 +100,7 @@ describe('Category B recompute when bottom count changes', () => {
     };
 
     // initial call with only 17 qualifiers (last pool second team missing)
-    let interim = updateCategoryBPhases(tournament);
+    const interim = updateCategoryBPhases(tournament);
 
     // now add wins for T34 to reach expected 18 qualifiers
     ['T34'].forEach(id => {

--- a/src/hooks/matchUpdates.ts
+++ b/src/hooks/matchUpdates.ts
@@ -11,8 +11,8 @@ export function updateMatchScore(
   team1Score: number,
   team2Score: number,
 ): Tournament {
-  let updatedMatches = [...tournament.matches];
-  let updatedMatchesB = [...tournament.matchesB];
+  const updatedMatches = [...tournament.matches];
+  const updatedMatchesB = [...tournament.matchesB];
 
   const idxA = updatedMatches.findIndex(m => m.id === matchId);
   const idxB = updatedMatchesB.findIndex(m => m.id === matchId);

--- a/src/hooks/poolManagement.ts
+++ b/src/hooks/poolManagement.ts
@@ -1,5 +1,5 @@
 import { Tournament, Team, Match } from '../types/tournament';
-import { generatePools, calculateOptimalPools } from '../utils/poolGeneration';
+import { generatePools } from '../utils/poolGeneration';
 import { generateUuid } from '../utils/uuid';
 import { createEmptyFinalPhases, createEmptyFinalPhasesB } from './finalsLogic';
 


### PR DESCRIPTION
## Summary
- shrink court column in the match table and balance other columns
- clean up unused variables in tests and hooks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c80cd919883248bd8179a9623885b