### PR TITLE
Translate tab names and adjust print layout

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -100,8 +100,8 @@ export function MatchesTab({
           <style>
             body { font-family: Arial, sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 20px; }
-            table { width: 100%; border-collapse: collapse; margin-top: 20px; table-layout: fixed; }
-            th, td { padding: 12px; border: 1px solid #ddd; }
+            table { width: 100%; border-collapse: collapse; margin-top: 20px; table-layout: fixed; border: 1px solid #000; }
+            th, td { padding: 12px; border: 1px solid #000; }
             th { background-color: #f2f2f2; font-weight: bold; }
             th.terrain, td.terrain { width: 10%; text-align: center; }
             th.team, td.team { width: 35%; }

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -11,12 +11,12 @@ export function TabNavigation({ activeTab, onTabChange, tournamentType }: TabNav
   const isPoolTournament = tournamentType === 'doublette-poule' || tournamentType === 'triplette-poule';
   
   const tabs = [
-    { id: 'teams', label: 'Teams', icon: Users },
+    { id: 'teams', label: 'Équipes', icon: Users },
     ...(isPoolTournament ? [{ id: 'pools', label: 'Poules', icon: Grid3X3 }] : []),
     ...(!isPoolTournament
       ? [
-          { id: 'matches', label: 'Matches', icon: Gamepad2 },
-          { id: 'standings', label: 'Standings', icon: Trophy },
+          { id: 'matches', label: 'Matchs', icon: Gamepad2 },
+          { id: 'standings', label: 'Classement', icon: Trophy },
         ]
       : []),
   ];


### PR DESCRIPTION
## Summary
- rename navigation tabs to French
- tweak printed match tables with clear borders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c84de0414832492fe3b209801fc18