### PR TITLE
Add lines to printed standings table

### DIFF
--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -40,8 +40,17 @@ export function StandingsTab({ teams }: StandingsTabProps) {
           <style>
             body { font-family: Arial, sans-serif; margin: 20px; }
             h1 { text-align: center; margin-bottom: 20px; }
-            table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-            th, td { padding: 12px; text-align: left; border: 1px solid #ddd; }
+            table {
+              width: 100%;
+              border-collapse: collapse;
+              margin-top: 20px;
+              border: 1px solid #555;
+            }
+            th, td {
+              padding: 12px;
+              text-align: left;
+              border: 1px solid #555;
+            }
             th { background-color: #f2f2f2; font-weight: bold; }
             tr:nth-child(even) { background-color: #f9f9f9; }
             .podium { background-color: #fff3cd; }


### PR DESCRIPTION
## Summary
- adjust the print CSS to draw borders around the standings table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c871c685c8324aa9eacfd3447a4e5