### PR TITLE
Center names in print table

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -104,8 +104,8 @@ export function MatchesTab({
             th, td { padding: 12px; border: 1px solid #000; }
             th { background-color: #f2f2f2; font-weight: bold; }
             th.terrain, td.terrain { width: 10%; text-align: center; }
-            th.team1, td.team1 { width: 35%; }
-            th.team2, td.team2 { width: 45%; }
+            th.team1, td.team1 { width: 35%; text-align: center; }
+            th.team2, td.team2 { width: 45%; text-align: center; }
         lyekm9-codex/ajouter-ligne-verticale-dans-colonne-score
             th.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; }
             td.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; position: relative; padding: 0; }


### PR DESCRIPTION
## Summary
- center team names in the match list print layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c8dad582483249cffb5bef6655254