### PR TITLE
Add deleteCurrentRound handler

### DIFF
--- a/src/hooks/__tests__/deleteCurrentRound.test.ts
+++ b/src/hooks/__tests__/deleteCurrentRound.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTournament } from '../useTournament';
+import { Tournament, Team, Player, Match } from '../../types/tournament';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('deleteCurrentRound', () => {
+  const makeTeam = (id: string): Team => ({
+    id,
+    name: id,
+    players: [] as Player[],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  });
+
+  it('removes matches of current round and decrements counter', () => {
+    const match1: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      team1Score: 13,
+      team2Score: 7,
+      completed: true,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const match2: Match = {
+      id: 'm2',
+      round: 2,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette',
+      courts: 1,
+      teams: [makeTeam('A'), makeTeam('B')],
+      matches: [match1, match2],
+      matchesB: [],
+      pools: [],
+      currentRound: 2,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.deleteCurrentRound();
+    });
+
+    const t = result.current.tournament!;
+    expect(t.currentRound).toBe(1);
+    expect(t.matches.find(m => m.id === 'm2')).toBeUndefined();
+    expect(t.matches.find(m => m.id === 'm1')).toBeDefined();
+    const teamA = t.teams.find(tm => tm.id === 'A')!;
+    expect(teamA.wins).toBe(1);
+    expect(teamA.pointsFor).toBe(13);
+  });
+
+  it('regenerates first round and resets stats when deleting round 1', () => {
+    const match1: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      team1Score: 13,
+      team2Score: 7,
+      completed: true,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette',
+      courts: 1,
+      teams: [makeTeam('A'), makeTeam('B')],
+      matches: [match1],
+      matchesB: [],
+      pools: [],
+      currentRound: 1,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.deleteCurrentRound();
+    });
+
+    const t = result.current.tournament!;
+    expect(t.currentRound).toBe(1);
+    expect(t.matches).toHaveLength(1);
+    const newMatch = t.matches[0];
+    expect(newMatch.completed).toBe(false);
+    const teamA = t.teams.find(tm => tm.id === 'A')!;
+    expect(teamA.wins).toBe(0);
+    expect(teamA.pointsFor).toBe(0);
+  });
+});

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -10,6 +10,7 @@ import {
 import {
   generateTournamentPools as generateTournamentPoolsLogic,
   generateRound as generateRoundLogic,
+  generateNextPoolMatches,
 } from './poolManagement';
 import {
   updateMatchScore as updateMatchScoreLogic,
@@ -20,6 +21,8 @@ import {
   getCurrentBottomTeams,
   initializeCategoryBBracket,
   autoGenerateNextMatches,
+  updateFinalPhasesWithQualified,
+  updateCategoryBPhases,
 } from './finalsLogic';
 import { calculateOptimalPools } from '../utils/poolGeneration';
 
@@ -35,6 +38,7 @@ export interface UseTournamentReturn {
   generateRound: () => void;
   updateMatchScore: (matchId: string, team1Score: number, team2Score: number) => void;
   updateMatchCourt: (matchId: string, court: number) => void;
+  deleteCurrentRound: () => void;
   resetTournament: () => void;
 }
 
@@ -209,6 +213,93 @@ export function useTournament(): UseTournamentReturn {
     saveTournament(updateMatchCourtLogic(tournament, matchId, court));
   };
 
+  const deleteCurrentRound = (): void => {
+    if (!tournament) return;
+    const roundToDelete = tournament.currentRound;
+    if (roundToDelete <= 0) return;
+
+    let updated: Tournament = {
+      ...tournament,
+      matches: tournament.matches.filter(m => m.round !== roundToDelete),
+      matchesB: tournament.matchesB.filter(m => m.round !== roundToDelete),
+      currentRound: Math.max(0, roundToDelete - 1),
+    };
+
+    if (roundToDelete === 1) {
+      const newMatches = generateMatches(updated);
+      updated = {
+        ...updated,
+        matches: [...updated.matches, ...newMatches],
+        currentRound: 1,
+      };
+    }
+
+    const allMatches = [...updated.matches, ...updated.matchesB];
+    const updatedTeams = updated.teams.map(team => {
+      const teamMatches = allMatches.filter(
+        match =>
+          match.completed &&
+          (match.team1Id === team.id ||
+            match.team2Id === team.id ||
+            (match.team1Ids && match.team1Ids.includes(team.id)) ||
+            (match.team2Ids && match.team2Ids.includes(team.id)))
+      );
+
+      let wins = 0;
+      let losses = 0;
+      let pointsFor = 0;
+      let pointsAgainst = 0;
+
+      teamMatches.forEach(match => {
+        if (match.isBye && (match.team1Id === team.id || match.team2Id === team.id)) {
+          wins += 1;
+          pointsFor += 13;
+          pointsAgainst += 7;
+          return;
+        }
+        const isTeam1 =
+          match.team1Id === team.id || (match.team1Ids && match.team1Ids.includes(team.id));
+        const isTeam2 =
+          match.team2Id === team.id || (match.team2Ids && match.team2Ids.includes(team.id));
+
+        if (isTeam1) {
+          pointsFor += match.team1Score || 0;
+          pointsAgainst += match.team2Score || 0;
+          if ((match.team1Score || 0) > (match.team2Score || 0)) {
+            wins += 1;
+          } else {
+            losses += 1;
+          }
+        } else if (isTeam2) {
+          pointsFor += match.team2Score || 0;
+          pointsAgainst += match.team1Score || 0;
+          if ((match.team2Score || 0) > (match.team1Score || 0)) {
+            wins += 1;
+          } else {
+            losses += 1;
+          }
+        }
+      });
+
+      return {
+        ...team,
+        wins,
+        losses,
+        pointsFor,
+        pointsAgainst,
+        performance: pointsFor - pointsAgainst,
+      };
+    });
+
+    updated = { ...updated, teams: updatedTeams };
+    const nextMatches = generateNextPoolMatches(updated);
+    updated = { ...updated, matches: nextMatches };
+    updated = updateFinalPhasesWithQualified(updated);
+    updated = updateCategoryBPhases(updated);
+    const auto = autoGenerateNextMatches(updated);
+    saveTournament(auto);
+  };
+
   const resetTournament = (): void => {
     localStorage.removeItem(STORAGE_KEY);
     setTournament(null);
@@ -224,6 +315,7 @@ export function useTournament(): UseTournamentReturn {
     generateRound,
     updateMatchScore,
     updateMatchCourt,
+    deleteCurrentRound,
     resetTournament,
   };
 }


### PR DESCRIPTION
## Summary
- implement `deleteCurrentRound` in useTournament
- recompute stats and regenerate first round if needed
- expose the new handler and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c9336848883249f48ffc32207e472