### PR TITLE
Fix stray print CSS markers

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -106,19 +106,16 @@ export function MatchesTab({
             th, td { padding: 12px; border: 1px solid #000; }
             th { background-color: #f2f2f2; font-weight: bold; }
             th.terrain, td.terrain { width: 10%; text-align: center; }
-        codex/centrer-les-noms-des-equipes-dans-l-impression
-            th.team1, td.team1 { width: 35%; text-align: center; }
-            th.team2, td.team2 { width: 45%; text-align: center; }
-        lyekm9-codex/ajouter-ligne-verticale-dans-colonne-score
-            th.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; }
-            td.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; position: relative; padding: 0; }
-            td.score::after { content: ''; position: absolute; top: 4px; bottom: 4px; left: 50%; border-left: 1px solid #000; }
+        th.team1, td.team1 { width: 35%; text-align: center; }
+        th.team2, td.team2 { width: 45%; text-align: center; }
+        th.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; }
+        td.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; position: relative; padding: 0; }
+        td.score::after { content: ''; position: absolute; top: 4px; bottom: 4px; left: 50%; border-left: 1px solid #000; }
 
 
-            th.team1, td.team1 { width: 35%; }
-            th.team2, td.team2 { width: 45%; }
-        main
-            th.score, td.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; position: relative; }
+        th.team1, td.team1 { width: 35%; }
+        th.team2, td.team2 { width: 45%; }
+        th.score, td.score { width: 10%; text-align: center; font-size: 18px; font-weight: bold; position: relative; }
             td.score { padding: 0; }
             td.score::after { content: ''; position: absolute; top: 4px; bottom: 4px; left: 50%; border-left: 1px solid #000; }
             td.score .score-box { display: flex; height: 100%; }


### PR DESCRIPTION
## Summary
- clean style block in `MatchesTab.tsx`

## Testing
- `npm test` *(fails: Duplicate identifier errors in useTournament.ts)*

------
https://chatgpt.com/codex/tasks/task_e_686c9ac6529483249df9bf41726158a9