### PR TITLE
Add round deletion feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
     generateTournamentPools,
     generateRound,
     deleteCurrentRound,
+    deleteRound,
     updateMatchScore,
     updateMatchCourt,
     resetTournament,
@@ -121,6 +122,7 @@ function App() {
             courts={tournament.courts}
             onGenerateRound={generateRound}
             onDeleteCurrentRound={deleteCurrentRound}
+            onDeleteRound={deleteRound}
             onUpdateScore={updateMatchScore}
             onUpdateCourt={updateMatchCourt}
           />

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -9,6 +9,7 @@ interface MatchesTabProps {
   courts: number;
   onGenerateRound: () => void;
   onDeleteCurrentRound: () => void;
+  onDeleteRound: (round: number) => void;
   onUpdateScore: (matchId: string, team1Score: number, team2Score: number) => void;
   onUpdateCourt: (matchId: string, court: number) => void;
 }
@@ -20,6 +21,7 @@ export function MatchesTab({
   courts,
   onGenerateRound,
   onDeleteCurrentRound,
+  onDeleteRound,
   onUpdateScore,
   onUpdateCourt
 }: MatchesTabProps) {
@@ -160,6 +162,10 @@ export function MatchesTab({
     printWindow.print();
   };
 
+  const handleDeleteRound = (round: number) => {
+    onDeleteRound(round);
+  };
+
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-8">
@@ -223,13 +229,21 @@ export function MatchesTab({
               <h3 className="text-xl font-bold text-white tracking-wide">
                 Tour {round}
               </h3>
-              <button
-                onClick={() => handlePrintRound(round)}
-                className="glass-button-secondary flex items-center space-x-2 px-4 py-2 font-bold text-sm tracking-wide hover:scale-105 transition-all duration-300"
-              >
-                <Printer className="w-4 h-4" />
-                <span>Imprimer</span>
-              </button>
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handlePrintRound(round)}
+                  className="glass-button-secondary flex items-center space-x-2 px-4 py-2 font-bold text-sm tracking-wide hover:scale-105 transition-all duration-300"
+                >
+                  <Printer className="w-4 h-4" />
+                  <span>Imprimer</span>
+                </button>
+                <button
+                  onClick={() => handleDeleteRound(round)}
+                  className="glass-button-secondary flex items-center space-x-2 px-3 py-2 font-bold text-sm tracking-wide hover:scale-105 transition-all duration-300 text-red-300 hover:text-red-200"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
             </div>
             <div className="overflow-x-auto">
               <table className="glass-table w-full table-fixed">

--- a/src/hooks/__tests__/deleteRound.test.ts
+++ b/src/hooks/__tests__/deleteRound.test.ts
@@ -1,0 +1,119 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTournament } from '../useTournament';
+import { Tournament, Team, Player, Match } from '../../types/tournament';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('deleteRound', () => {
+  const makeTeam = (id: string): Team => ({
+    id,
+    name: id,
+    players: [] as Player[],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  });
+
+  it('removes matches of given round and updates currentRound', () => {
+    const match1: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      team1Score: 13,
+      team2Score: 7,
+      completed: true,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const match2: Match = {
+      id: 'm2',
+      round: 2,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette',
+      courts: 1,
+      teams: [makeTeam('A'), makeTeam('B')],
+      matches: [match1, match2],
+      matchesB: [],
+      pools: [],
+      currentRound: 2,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.deleteRound(1);
+    });
+
+    const t = result.current.tournament!;
+    expect(t.currentRound).toBe(2);
+    expect(t.matches.find(m => m.id === 'm1')).toBeUndefined();
+    expect(t.matches.find(m => m.id === 'm2')).toBeDefined();
+  });
+
+  it('deleting last round decrements currentRound', () => {
+    const match1: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'A',
+      team2Id: 'B',
+      completed: true,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+    const initial: Tournament = {
+      id: 't1',
+      name: 'Test',
+      type: 'doublette',
+      courts: 1,
+      teams: [makeTeam('A'), makeTeam('B')],
+      matches: [match1],
+      matchesB: [],
+      pools: [],
+      currentRound: 1,
+      completed: false,
+      createdAt: new Date(),
+      securityLevel: 1,
+      networkStatus: 'online',
+      poolsGenerated: false,
+    };
+
+    localStorage.setItem('petanque-tournament', JSON.stringify(initial));
+    const { result } = renderHook(() => useTournament());
+
+    act(() => {
+      result.current.deleteRound(1);
+    });
+
+    const t = result.current.tournament!;
+    expect(t.currentRound).toBe(0);
+    expect(t.matches).toHaveLength(0);
+  });
+});
+

--- a/src/hooks/matchUpdates.ts
+++ b/src/hooks/matchUpdates.ts
@@ -104,3 +104,30 @@ export function deleteCurrentRound(tournament: Tournament): Tournament {
   return updatedTournament;
 }
 
+export function deleteRound(tournament: Tournament, round: number): Tournament {
+  const updatedMatches = tournament.matches.filter(m => m.round !== round);
+  const updatedMatchesB = tournament.matchesB.filter(m => m.round !== round);
+
+  const allMatches = [...updatedMatches, ...updatedMatchesB];
+  const updatedTeams = computeTeamStats(
+    { ...tournament, matches: updatedMatches, matchesB: updatedMatchesB },
+    allMatches,
+  );
+
+  const maxRound = allMatches.length > 0 ? Math.max(...allMatches.map(m => m.round)) : 0;
+
+  let updatedTournament: Tournament = {
+    ...tournament,
+    matches: updatedMatches,
+    matchesB: updatedMatchesB,
+    teams: updatedTeams,
+    currentRound: maxRound,
+  };
+
+  const nextMatches = generateNextPoolMatches(updatedTournament);
+  updatedTournament = { ...updatedTournament, matches: nextMatches };
+  updatedTournament = updateFinalPhasesWithQualified(updatedTournament);
+  updatedTournament = updateCategoryBPhases(updatedTournament);
+  return updatedTournament;
+}
+

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -10,20 +10,18 @@ import {
 import {
   generateTournamentPools as generateTournamentPoolsLogic,
   generateRound as generateRoundLogic,
-  generateNextPoolMatches,
 } from './poolManagement';
 import {
   updateMatchScore as updateMatchScoreLogic,
   updateMatchCourt as updateMatchCourtLogic,
   deleteCurrentRound as deleteCurrentRoundLogic,
+  deleteRound as deleteRoundLogic,
 } from './matchUpdates';
 import {
   createEmptyFinalPhasesB,
   getCurrentBottomTeams,
   initializeCategoryBBracket,
   autoGenerateNextMatches,
-  updateFinalPhasesWithQualified,
-  updateCategoryBPhases,
 } from './finalsLogic';
 import { calculateOptimalPools } from '../utils/poolGeneration';
 
@@ -38,6 +36,7 @@ export interface UseTournamentReturn {
   generateTournamentPools: () => void;
   generateRound: () => void;
   deleteCurrentRound: () => void;
+  deleteRound: (round: number) => void;
   updateMatchScore: (matchId: string, team1Score: number, team2Score: number) => void;
   updateMatchCourt: (matchId: string, court: number) => void;
   resetTournament: () => void;
@@ -222,6 +221,13 @@ export function useTournament(): UseTournamentReturn {
     saveTournament(auto);
   };
 
+  const deleteRound = (round: number): void => {
+    if (!tournament) return;
+    const updated = deleteRoundLogic(tournament, round);
+    const auto = autoGenerateNextMatches(updated);
+    saveTournament(auto);
+  };
+
   const resetTournament = (): void => {
     localStorage.removeItem(STORAGE_KEY);
     setTournament(null);
@@ -236,6 +242,7 @@ export function useTournament(): UseTournamentReturn {
     generateTournamentPools,
     generateRound,
     deleteCurrentRound,
+    deleteRound,
     updateMatchScore,
     updateMatchCourt,
     resetTournament,


### PR DESCRIPTION
## Summary
- support removing any round via `deleteRound`
- expose new method from `useTournament`
- add delete buttons for each round
- test deleting arbitrary rounds

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c9e2e4480832490062ad99b1d0007