### PR TITLE
Randomize first round pairings

### DIFF
--- a/src/utils/__tests__/standardMatchmaking.test.ts
+++ b/src/utils/__tests__/standardMatchmaking.test.ts
@@ -1,0 +1,78 @@
+import { generateMatches } from '../matchmaking';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+function makePlayer(id: string): Player {
+  return {
+    id,
+    name: `Player ${id}`,
+    cyberImplants: [],
+    neuralScore: 0,
+    combatRating: 0,
+    hackingLevel: 0,
+    augmentationLevel: 0,
+  };
+}
+
+function makeTeam(id: string): Team {
+  return {
+    id,
+    name: id,
+    players: [makePlayer(id)],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  };
+}
+
+function baseTournament(teams: Team[]): Tournament {
+  return {
+    id: 't',
+    name: 'Test',
+    type: 'doublette',
+    courts: 1,
+    teams,
+    matches: [],
+    matchesB: [],
+    pools: [],
+    currentRound: 0,
+    completed: false,
+    createdAt: new Date(),
+    securityLevel: 1,
+    networkStatus: 'online',
+    poolsGenerated: false,
+  };
+}
+
+describe('generateStandardMatches first round', () => {
+  it('pairs all teams exactly once for even counts', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+    const matches = generateMatches(tournament);
+    expect(matches).toHaveLength(2);
+    const ids = new Set<string>();
+    matches.forEach(m => {
+      ids.add(m.team1Id);
+      if (!m.isBye) ids.add(m.team2Id);
+    });
+    expect(Array.from(ids).sort()).toEqual(teams.map(t => t.id).sort());
+  });
+
+  it('assigns one team a BYE when the count is odd', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C')];
+    const tournament = baseTournament(teams);
+    const matches = generateMatches(tournament);
+    expect(matches).toHaveLength(2); // 1 match + 1 bye
+    const bye = matches.find(m => m.isBye);
+    expect(bye).toBeDefined();
+    const ids = new Set<string>();
+    matches.forEach(m => {
+      ids.add(m.team1Id);
+      if (!m.isBye) ids.add(m.team2Id);
+    });
+    expect(Array.from(ids).sort()).toEqual(teams.map(t => t.id).sort());
+  });
+});

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -16,16 +16,18 @@ function generateStandardMatches(tournament: Tournament): Match[] {
   const { teams, matches, currentRound } = tournament;
   const round = currentRound + 1;
 
-  // Sort teams by performance (best to worst)
-  const sortedTeams = [...teams].sort((a, b) => b.performance - a.performance);
+  const remainingTeams =
+    round === 1
+      ? [...teams].sort(() => Math.random() - 0.5)
+      : [...teams].sort((a, b) => b.performance - a.performance);
 
-  const remainingTeams = [...sortedTeams];
   const newMatches: Match[] = [];
 
   if (round === 1) {
-    // Handle BYE if the number of teams is odd
+    // Handle BYE if the number of teams is odd by randomly selecting a team
     if (remainingTeams.length % 2 === 1) {
-      const byeTeam = remainingTeams.pop() as Team;
+      const byeIndex = Math.floor(Math.random() * remainingTeams.length);
+      const [byeTeam] = remainingTeams.splice(byeIndex, 1);
       newMatches.push({
         id: generateUuid(),
         round,
@@ -42,49 +44,15 @@ function generateStandardMatches(tournament: Tournament): Match[] {
     }
 
     let courtIndex = 1;
-
-    // Pair by groups of four using the 1 vs 3, 2 vs 4 pattern
-    let i = 0;
-    for (; i + 3 < remainingTeams.length; i += 4) {
-      const t1 = remainingTeams[i];
-      const t2 = remainingTeams[i + 2];
+    for (let i = 0; i < remainingTeams.length - 1; i += 2) {
+      const team1 = remainingTeams[i];
+      const team2 = remainingTeams[i + 1];
       newMatches.push({
         id: generateUuid(),
         round,
         court: courtIndex++,
-        team1Id: t1.id,
-        team2Id: t2.id,
-        completed: false,
-        isBye: false,
-        battleIntensity: Math.floor(Math.random() * 50) + 25,
-        hackingAttempts: 0,
-      });
-
-      const t3 = remainingTeams[i + 1];
-      const t4 = remainingTeams[i + 3];
-      newMatches.push({
-        id: generateUuid(),
-        round,
-        court: courtIndex++,
-        team1Id: t3.id,
-        team2Id: t4.id,
-        completed: false,
-        isBye: false,
-        battleIntensity: Math.floor(Math.random() * 50) + 25,
-        hackingAttempts: 0,
-      });
-    }
-
-    // Pair any remaining teams sequentially
-    for (; i < remainingTeams.length - 1; i += 2) {
-      const t1 = remainingTeams[i];
-      const t2 = remainingTeams[i + 1];
-      newMatches.push({
-        id: generateUuid(),
-        round,
-        court: courtIndex++,
-        team1Id: t1.id,
-        team2Id: t2.id,
+        team1Id: team1.id,
+        team2Id: team2.id,
         completed: false,
         isBye: false,
         battleIntensity: Math.floor(Math.random() * 50) + 25,


### PR DESCRIPTION
## Summary
- shuffle teams for standard tournaments when generating round 1
- select BYE team randomly
- create `standardMatchmaking.test.ts` covering first round logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ca626354883249069dcd80b17a9d3