### PR TITLE
Avoid pairing consecutive teams in first round

### DIFF
--- a/src/utils/__tests__/standardMatchmaking.test.ts
+++ b/src/utils/__tests__/standardMatchmaking.test.ts
@@ -75,4 +75,24 @@ describe('generateStandardMatches first round', () => {
     });
     expect(Array.from(ids).sort()).toEqual(teams.map(t => t.id).sort());
   });
+
+  it('avoids pairing consecutive teams when possible', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.4);
+
+    const matches = generateMatches(tournament);
+    randomSpy.mockRestore();
+
+    const baseOrder = teams.map(t => t.id);
+    const hasSequential = matches.some(m => {
+      if (m.isBye) return false;
+      const diff = Math.abs(
+        baseOrder.indexOf(m.team1Id) - baseOrder.indexOf(m.team2Id)
+      );
+      return diff === 1;
+    });
+    expect(hasSequential).toBe(false);
+  });
 });

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -43,10 +43,25 @@ function generateStandardMatches(tournament: Tournament): Match[] {
       });
     }
 
+    const baseOrder = teams.map(t => t.id);
     let courtIndex = 1;
     for (let i = 0; i < remainingTeams.length - 1; i += 2) {
       const team1 = remainingTeams[i];
-      const team2 = remainingTeams[i + 1];
+      let team2 = remainingTeams[i + 1];
+
+      if (
+        Math.abs(baseOrder.indexOf(team1.id) - baseOrder.indexOf(team2.id)) === 1 &&
+        i + 2 < remainingTeams.length
+      ) {
+        const swapIdx = remainingTeams.slice(i + 2).findIndex(t =>
+          Math.abs(baseOrder.indexOf(team1.id) - baseOrder.indexOf(t.id)) !== 1
+        );
+        if (swapIdx !== -1) {
+          const actual = i + 2 + swapIdx;
+          [remainingTeams[i + 1], remainingTeams[actual]] = [remainingTeams[actual], remainingTeams[i + 1]];
+          team2 = remainingTeams[i + 1];
+        }
+      }
       newMatches.push({
         id: generateUuid(),
         round,


### PR DESCRIPTION
## Summary
- shuffle teams then ensure first round doesn't pair sequential registrations
- add regression test for new matching rule

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ca803c67c832487fdc32e7b6fd7ba