### PR TITLE
Remove stray markers from CSS and JSX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,13 +145,10 @@ function App() {
         <div className="petanque-ball"></div>
         <div className="petanque-ball"></div>
         <div className="petanque-ball"></div>
-        gc9qdc-codex/ajouter-6-7-boules-au-fond-anime
         <div className="petanque-ball"></div>
         <div className="petanque-ball"></div>
         <div className="petanque-ball"></div>
         <div className="petanque-ball"></div>
-
-        main
       </div>
 
       <Header animationsPaused={animationsPaused} onToggleAnimations={toggleAnimations} />

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -8,7 +8,6 @@ interface MatchesTabProps {
   currentRound: number;
   courts: number;
   onGenerateRound: () => void;
-  onDeleteCurrentRound: () => void;
   onDeleteRound: (round: number) => void;
   onUpdateScore: (matchId: string, team1Score: number, team2Score: number) => void;
   onUpdateCourt: (matchId: string, court: number) => void;
@@ -20,7 +19,6 @@ export function MatchesTab({
   currentRound,
   courts,
   onGenerateRound,
-  onDeleteCurrentRound,
   onDeleteRound,
   onUpdateScore,
   onUpdateCourt

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 @layer base {
   * {
@@ -515,7 +515,6 @@
     right: 40%;
     animation-delay: -18s;
     animation-duration: 21s;
-        gc9qdc-codex/ajouter-6-7-boules-au-fond-anime
   }
 
   .petanque-ball:nth-child(8) {
@@ -552,8 +551,6 @@
     left: 50%;
     animation-delay: -18s;
     animation-duration: 23s;
-
-        main
   }
 
   @keyframes floatPetanque {


### PR DESCRIPTION
## Summary
- clean up stray debugging lines in CSS and JSX
- fix lint failure by removing unused prop
- reorder CSS import
- verify build and lint pass

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686cacfbd37c83249deba37f6ed9afc6