### PR TITLE
Fix asset references for packaged Electron app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/petanque-icon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./petanque-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pétanque Manager</title>
   </head>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import logoUrl from '../../logo1.png';
 
 interface LogoProps {
   className?: string;
@@ -6,6 +7,6 @@ interface LogoProps {
 
 export function Logo({ className = "w-12 h-12" }: LogoProps) {
   return (
-    <img src="/logo1.png" alt="Logo" className={className} />
+    <img src={logoUrl} alt="Logo" className={className} />
   );
 }


### PR DESCRIPTION
## Summary
- ensure favicon uses a relative path
- import logo asset so it bundles correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cb47889e4832490f70b67ecde939c