### PR TITLE
Fix player group labels in match display

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -50,14 +50,13 @@ export function MatchesTab({
 
   const getGroupLabel = (ids: string[]) => {
     const labels = ids.map(id => {
-      const index = teams.findIndex(t => t.id === id);
-      const team = teams[index];
-      if (!team) return 'Inconnu';
-      if (isSolo) {
-        const player = team.players[0];
-        return `${index + 1} : ${player.name}`;
+      for (const team of teams) {
+        const player = team.players.find(p => p.id === id);
+        if (player) {
+          return player.label ? `[${player.label}] ${player.name}` : player.name;
+        }
       }
-      return team.name || team.players[0]?.name || 'Inconnu';
+      return 'Inconnu';
     });
     return labels.join(isSolo ? ' - ' : ' + ');
   };


### PR DESCRIPTION
## Summary
- correct `getGroupLabel` in `MatchesTab` to display player names

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687134b72a8c8324a5b0b5bcdced663b