### PR TITLE
Fix quadrette IDs in matches

### DIFF
--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -62,11 +62,14 @@ describe('generateQuadretteMatches', () => {
     const matches = generateMatches(tournament);
     expect(matches).toHaveLength(2);
     expect(matches.every(m => m.team1Id !== m.team2Id)).toBe(true);
-    const withGroup = matches.find(m => m.team1Ids);
-    const solo = matches.find(m => !m.team1Ids);
+    const withGroup = matches.find(m => m.team1Ids && m.team1Ids.length > 1);
+    const solo = matches.find(m => m.team1Ids && m.team1Ids.length === 1);
     expect(withGroup).toBeDefined();
     expect(withGroup!.team1Ids).toHaveLength(3);
+    expect(withGroup!.team2Ids).toHaveLength(3);
     expect(solo).toBeDefined();
+    expect(solo!.team1Ids).toHaveLength(1);
+    expect(solo!.team2Ids).toHaveLength(1);
   });
 
   it('avoids pairing the same teams more than once', () => {

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -192,8 +192,8 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
         hackingAttempts: 0,
       };
 
-      if (ids1.length > 1) match.team1Ids = ids1;
-      if (ids2.length > 1) match.team2Ids = ids2;
+      match.team1Ids = ids1;
+      match.team2Ids = ids2;
 
       newMatches.push(match);
       courtIndex++;


### PR DESCRIPTION
## Summary
- always populate team1Ids/team2Ids when generating quadrette matches
- update quadrette matchmaking test to expect arrays of length 1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68716bebd3e48324bf9023d0b9012625