### PR TITLE
Improve group label display

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -49,16 +49,23 @@ export function MatchesTab({
 
   const getGroupLabel = (ids: string[]) => {
     const players: Player[] = [];
-    ids.forEach(id => {
-      for (const team of teams) {
+    let teamNumber: number | undefined;
+
+    ids.forEach((id, idx) => {
+      for (let i = 0; i < teams.length; i++) {
+        const team = teams[i];
         const player = team.players.find(p => p.id === id);
         if (player) {
           players.push(player);
+          if (idx === 0) {
+            teamNumber = i + 1;
+          }
           break;
         }
       }
     });
-    return formatPlayers(players);
+
+    return formatPlayers(players, teamNumber);
   };
 
   const handleEditScore = (match: Match) => {


### PR DESCRIPTION
## Summary
- show team number in group labels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68716bed3a788324a3ad88976ee52a4b