### PR TITLE
Update quadrette tests for team arrays

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,4 +4,9 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.app.json',
+    },
+  },
 };

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -293,7 +293,11 @@ export function MatchesTab({
                       </td>
                       <td className="w-4/12 px-4 py-4 whitespace-nowrap text-center">
                           {match.team1Ids ? (
-                            <span className="font-bold text-white">{getGroupLabel(match.team1Ids)}</span>
+                            match.team1Ids.length === 1 ? (
+                              <span className="font-bold text-white">{getTeamDisplay(match.team1Id)}</span>
+                            ) : (
+                              <span className="font-bold text-white">{getGroupLabel(match.team1Ids)}</span>
+                            )
                           ) : (
                             <span className="font-bold text-white">{getTeamDisplay(match.team1Id)}</span>
                           )}
@@ -329,7 +333,11 @@ export function MatchesTab({
                           {match.isBye ? (
                             <span className="text-white/50 italic font-bold">BYE</span>
                           ) : match.team2Ids ? (
-                            <span className="font-bold text-white">{getGroupLabel(match.team2Ids)}</span>
+                            match.team2Ids.length === 1 ? (
+                              <span className="font-bold text-white">{getTeamDisplay(match.team2Id)}</span>
+                            ) : (
+                              <span className="font-bold text-white">{getGroupLabel(match.team2Ids)}</span>
+                            )
                           ) : (
                             <span className="font-bold text-white">{getTeamDisplay(match.team2Id)}</span>
                           )}

--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MatchesTab } from '../MatchesTab';
+import { generateMatches } from '../../utils/matchmaking';
+import { Tournament, Team, Player } from '../../types/tournament';
+
+function makePlayer(id: string, label: string): Player {
+  return {
+    id,
+    name: id,
+    label,
+    cyberImplants: [],
+    neuralScore: 0,
+    combatRating: 0,
+    hackingLevel: 0,
+    augmentationLevel: 0,
+  };
+}
+
+function makeTeam(id: string): Team {
+  return {
+    id,
+    name: id,
+    players: [
+      makePlayer(`${id}-A`, 'A'),
+      makePlayer(`${id}-B`, 'B'),
+      makePlayer(`${id}-C`, 'C'),
+      makePlayer(`${id}-D`, 'D'),
+    ],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    teamRating: 0,
+    synchroLevel: 0,
+  };
+}
+
+function baseTournament(teams: Team[]): Tournament {
+  return {
+    id: 't',
+    name: 'Test',
+    type: 'quadrette',
+    courts: 1,
+    teams,
+    matches: [],
+    matchesB: [],
+    pools: [],
+    currentRound: 0,
+    completed: false,
+    createdAt: new Date(),
+    securityLevel: 1,
+    networkStatus: 'online',
+    poolsGenerated: false,
+  };
+}
+
+describe('MatchesTab display', () => {
+  it('shows team numbers in player list', () => {
+    const teams = [makeTeam('T1'), makeTeam('T2')];
+    const matches = generateMatches(baseTournament(teams));
+
+    render(
+      <MatchesTab
+        matches={matches}
+        teams={teams}
+        currentRound={0}
+        courts={1}
+        onGenerateRound={() => {}}
+        onDeleteRound={() => {}}
+        onUpdateScore={() => {}}
+        onUpdateCourt={() => {}}
+      />
+    );
+    // Debug DOM output for inspection
+    // screen.debug();
+
+    const text = document.body.textContent || '';
+    expect(text).toContain('a1 - T1-A');
+    expect(text).toContain('a2 - T2-A');
+  });
+});

--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -62,11 +62,12 @@ describe('generateQuadretteMatches', () => {
     const matches = generateMatches(tournament);
     expect(matches).toHaveLength(2);
     expect(matches.every(m => m.team1Id !== m.team2Id)).toBe(true);
-    const withGroup = matches.find(m => m.team1Ids);
-    const solo = matches.find(m => !m.team1Ids);
-    expect(withGroup).toBeDefined();
-    expect(withGroup!.team1Ids).toHaveLength(3);
-    expect(solo).toBeDefined();
+    const triplette = matches.find(m => m.team1Ids && m.team1Ids.length === 3);
+    const tete = matches.find(m => m.team1Ids && m.team1Ids.length === 1);
+    expect(triplette).toBeDefined();
+    expect(triplette!.team2Ids).toHaveLength(3);
+    expect(tete).toBeDefined();
+    expect(tete!.team2Ids).toHaveLength(1);
   });
 
   it('avoids pairing the same teams more than once', () => {

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -192,8 +192,8 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
         hackingAttempts: 0,
       };
 
-      if (ids1.length > 1) match.team1Ids = ids1;
-      if (ids2.length > 1) match.team2Ids = ids2;
+      match.team1Ids = ids1;
+      match.team2Ids = ids2;
 
       newMatches.push(match);
       courtIndex++;


### PR DESCRIPTION
## Summary
- improve `generateQuadretteMatches` test to assert team arrays
- add Jest test for team numbering in `MatchesTab`
- adjust `MatchesTab` display logic to show numbers for single-player groups
- expose ts-jest `tsconfig`
- always set `team1Ids` and `team2Ids` in `generateQuadretteMatches`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68716beedcd48324868ae6fd9b3536bc