### PR TITLE
Fix group label display for single players

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -300,11 +300,7 @@ export function MatchesTab({
                       </td>
                       <td className="w-4/12 px-4 py-4 whitespace-nowrap text-center">
                           {match.team1Ids ? (
-                            match.team1Ids.length === 1 ? (
-                              <span className="font-bold text-white">{getTeamDisplay(match.team1Id)}</span>
-                            ) : (
-                              <span className="font-bold text-white">{getGroupLabel(match.team1Ids)}</span>
-                            )
+                            <span className="font-bold text-white">{getGroupLabel(match.team1Ids)}</span>
                           ) : (
                             <span className="font-bold text-white">{getTeamDisplay(match.team1Id)}</span>
                           )}
@@ -340,11 +336,7 @@ export function MatchesTab({
                           {match.isBye ? (
                             <span className="text-white/50 italic font-bold">BYE</span>
                           ) : match.team2Ids ? (
-                            match.team2Ids.length === 1 ? (
-                              <span className="font-bold text-white">{getTeamDisplay(match.team2Id)}</span>
-                            ) : (
-                              <span className="font-bold text-white">{getGroupLabel(match.team2Ids)}</span>
-                            )
+                            <span className="font-bold text-white">{getGroupLabel(match.team2Ids)}</span>
                           ) : (
                             <span className="font-bold text-white">{getTeamDisplay(match.team2Id)}</span>
                           )}

--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -78,7 +78,7 @@ describe('MatchesTab display', () => {
     // screen.debug();
 
     const text = document.body.textContent || '';
-    expect(text).toContain('a1 - T1-A');
-    expect(text).toContain('a2 - T2-A');
+    expect(text).toContain('1a - T1-A');
+    expect(text).toContain('2a - T2-A');
   });
 });


### PR DESCRIPTION
## Summary
- always call `getGroupLabel` when `teamIds` exist
- update test expectations for formatted player output

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68717fb619288324afc1b4922d19ac2e