### PR TITLE
Add quadrette multi-round test

### DIFF
--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -78,17 +78,13 @@ describe('MatchesTab display', () => {
     // screen.debug();
 
     const text = document.body.textContent || '';
-        codex/modifier-handleprint-pour-tous-les-types-de-tournoi
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
-        codex/modifier-conditionnel-pour-getgrouplabel
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
+    expect(text).toContain('1 : A - T1-A');
+    expect(text).toContain('2 : A - T2-A');
 
     expect(text).toContain('1 : A - T1-A');
     expect(text).toContain('2 : A - T2-A');
-        main
-        main
+
+    expect(text).toContain('1 : A - T1-A');
+    expect(text).toContain('2 : A - T2-A');
   });
 });

--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -94,4 +94,30 @@ describe('generateQuadretteMatches', () => {
     const matches = generateMatches(tournament);
     expect(matches).toHaveLength(0);
   });
+
+  it('generates matches for multiple rounds covering all teams', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+
+    const patternsPerRound = 2; // schedule defines two match patterns per round
+    const roundsToPlay = 3;
+
+    for (let r = 0; r < roundsToPlay; r++) {
+      const newMatches = generateMatches(tournament);
+
+      // number of matches should equal (team count / 2) * patternsPerRound
+      expect(newMatches).toHaveLength((teams.length / 2) * patternsPerRound);
+
+      // every team should appear in the round's matches
+      teams.forEach(team => {
+        const involved = newMatches.some(
+          m => m.team1Id === team.id || m.team2Id === team.id
+        );
+        expect(involved).toBe(true);
+      });
+
+      tournament.matches.push(...newMatches);
+      tournament.currentRound += 1;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a quadrette matchmaking test that verifies all teams are matched for several rounds
- update MatchesTab expectation to new team label format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871871dda3483248c9207483542236e