### PR TITLE
Fix quadrette pairing logic

### DIFF
--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -78,17 +78,7 @@ describe('MatchesTab display', () => {
     // screen.debug();
 
     const text = document.body.textContent || '';
-        codex/modifier-handleprint-pour-tous-les-types-de-tournoi
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
-        codex/modifier-conditionnel-pour-getgrouplabel
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
     expect(text).toContain('1 : A - T1-A');
     expect(text).toContain('2 : A - T2-A');
-        main
-        main
   });
 });

--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -87,6 +87,23 @@ describe('generateQuadretteMatches', () => {
     expect(pairs.size * 2).toBe(tournament.matches.length);
   });
 
+  it('includes every team in each generated round', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+
+    for (let i = 0; i < 5; i++) {
+      const roundMatches = generateMatches(tournament);
+      const ids = new Set<string>();
+      roundMatches.forEach(m => {
+        ids.add(m.team1Id);
+        ids.add(m.team2Id);
+      });
+      expect(Array.from(ids).sort()).toEqual(teams.map(t => t.id).sort());
+      tournament.matches.push(...roundMatches);
+      tournament.currentRound += 1;
+    }
+  });
+
   it('returns no matches after round seven', () => {
     const teams = [makeTeam('A'), makeTeam('B')];
     const tournament = baseTournament(teams);

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -182,15 +182,13 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
     });
   });
 
-  const remaining = [...teams];
+  const remaining = [...teams].sort(() => Math.random() - 0.5);
   const pairings: [Team, Team][] = [];
 
   while (remaining.length > 1) {
     const team1 = remaining.shift() as Team;
-    const idx = remaining.findIndex(t => !haveBaseTeamsPlayedBefore(team1.id, t.id, matches));
-    if (idx === -1) {
-      continue; // no available opponent
-    }
+    let idx = remaining.findIndex(t => !haveBaseTeamsPlayedBefore(team1.id, t.id, matches));
+    if (idx === -1) idx = 0;
     const team2 = remaining.splice(idx, 1)[0];
     pairings.push([team1, team2]);
   }


### PR DESCRIPTION
## Summary
- randomize team order in quadrette matchmaking
- ensure each team always gets paired
- update MatchesTab test
- ensure quadrette rounds include all teams

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687186d0d15c8324bd047ae6d4d7a949