### PR TITLE
Allow separate opponents for quadrette matches

### DIFF
--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -78,17 +78,7 @@ describe('MatchesTab display', () => {
     // screen.debug();
 
     const text = document.body.textContent || '';
-        codex/modifier-handleprint-pour-tous-les-types-de-tournoi
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
-        codex/modifier-conditionnel-pour-getgrouplabel
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
     expect(text).toContain('1 : A - T1-A');
     expect(text).toContain('2 : A - T2-A');
-        main
-        main
   });
 });

--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -71,6 +71,35 @@ describe('generateQuadretteMatches', () => {
     expect(tete!.team2Ids).toHaveLength(1);
   });
 
+  it('can pair a team with different opponents for triplette and tête-à-tête', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+
+    const seq = [0, 0, 0, 0.75, 0.75, 0.75, 0.1, 0.2, 0.3, 0.4];
+    let idx = 0;
+    jest.spyOn(Math, 'random').mockImplementation(() => seq[idx++] ?? 0);
+
+    const matches = generateMatches(tournament);
+
+    const triplette = matches.filter(m => m.team1Ids && m.team1Ids.length === 3);
+    const tete = matches.filter(m => m.team1Ids && m.team1Ids.length === 1);
+
+    const tripMap: Record<string, string> = {};
+    triplette.forEach(m => {
+      tripMap[m.team1Id] = m.team2Id;
+      tripMap[m.team2Id] = m.team1Id;
+    });
+
+    const teteMap: Record<string, string> = {};
+    tete.forEach(m => {
+      teteMap[m.team1Id] = m.team2Id;
+      teteMap[m.team2Id] = m.team1Id;
+    });
+
+    const hasDifferent = Object.keys(tripMap).some(id => tripMap[id] !== teteMap[id]);
+    expect(hasDifferent).toBe(true);
+  });
+
   it('avoids pairing the same teams more than once', () => {
     const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
     const tournament = baseTournament(teams);

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -182,44 +182,95 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
     });
   });
 
-  const remaining = [...teams];
-  const pairings: [Team, Team][] = [];
+  const pairKey = (a: string, b: string) => [a, b].sort().join('-');
 
-  while (remaining.length > 1) {
-    const team1 = remaining.shift() as Team;
-    const idx = remaining.findIndex(t => !haveBaseTeamsPlayedBefore(team1.id, t.id, matches));
-    if (idx === -1) {
-      continue; // no available opponent
+  function shuffle<T>(arr: T[]): T[] {
+    const copy = [...arr];
+    for (let i = copy.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
     }
-    const team2 = remaining.splice(idx, 1)[0];
-    pairings.push([team1, team2]);
+    return copy;
   }
 
+  function makePairings(exclude: Set<string>): [Team, Team][] {
+    const order = shuffle(teams);
+    const remain = [...order];
+    const result: [Team, Team][] = [];
+
+    while (remain.length > 1) {
+      const team1 = remain.shift() as Team;
+      let idx = remain.findIndex(
+        t => !haveBaseTeamsPlayedBefore(team1.id, t.id, matches) && !exclude.has(pairKey(team1.id, t.id))
+      );
+      if (idx === -1) {
+        idx = remain.findIndex(t => !exclude.has(pairKey(team1.id, t.id)));
+      }
+      if (idx === -1) idx = 0;
+      const team2 = remain.splice(idx, 1)[0];
+      exclude.add(pairKey(team1.id, team2.id));
+      result.push([team1, team2]);
+    }
+
+    return result;
+  }
+
+  const usedPairs = new Set<string>();
+  const triplettePairings = makePairings(usedPairs);
+  const tetePairings = makePairings(usedPairs);
+
   let courtIndex = 1;
-  pairings.forEach(([t1, t2]) => {
-    roundPatterns.forEach(([p1, p2]) => {
-      const ids1 = p1.split('').map(l => playerMap[t1.id][l]).filter(Boolean);
-      const ids2 = p2.split('').map(l => playerMap[t2.id][l]).filter(Boolean);
+  const [triplettePattern, tetePattern] = roundPatterns;
 
-      const match: Match = {
-        id: generateUuid(),
-        round,
-        court: ((courtIndex - 1) % courts) + 1,
-        team1Id: t1.id,
-        team2Id: t2.id,
-        completed: false,
-        isBye: false,
-        battleIntensity: Math.floor(Math.random() * 100) + 50,
-        hackingAttempts: 0,
-      };
+  triplettePairings.forEach(([t1, t2]) => {
+    const [p1, p2] = triplettePattern;
+    const ids1 = p1.split('').map(l => playerMap[t1.id][l]).filter(Boolean);
+    const ids2 = p2.split('').map(l => playerMap[t2.id][l]).filter(Boolean);
 
-      match.team1Ids = ids1;
-      match.team2Ids = ids2;
+    const match: Match = {
+      id: generateUuid(),
+      round,
+      court: ((courtIndex - 1) % courts) + 1,
+      team1Id: t1.id,
+      team2Id: t2.id,
+      completed: false,
+      isBye: false,
+      battleIntensity: Math.floor(Math.random() * 100) + 50,
+      hackingAttempts: 0,
+    };
 
-      newMatches.push(match);
-      courtIndex++;
-    });
+    match.team1Ids = ids1;
+    match.team2Ids = ids2;
+
+    newMatches.push(match);
+    courtIndex++;
   });
+
+  tetePairings.forEach(([t1, t2]) => {
+    const [p1, p2] = tetePattern;
+    const ids1 = p1.split('').map(l => playerMap[t1.id][l]).filter(Boolean);
+    const ids2 = p2.split('').map(l => playerMap[t2.id][l]).filter(Boolean);
+
+    const match: Match = {
+      id: generateUuid(),
+      round,
+      court: ((courtIndex - 1) % courts) + 1,
+      team1Id: t1.id,
+      team2Id: t2.id,
+      completed: false,
+      isBye: false,
+      battleIntensity: Math.floor(Math.random() * 100) + 50,
+      hackingAttempts: 0,
+    };
+
+    match.team1Ids = ids1;
+    match.team2Ids = ids2;
+
+    newMatches.push(match);
+    courtIndex++;
+  });
+
+  return newMatches;
 
   return newMatches;
 }


### PR DESCRIPTION
## Summary
- extend quadrette matchmaking so triplette and tête-à-tête can be against different opponents
- add unit test for this new behaviour
- clean up MatchesTab test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718705876c83248c5cf0c1b11f6c59