### PR TITLE
Improve quadrette shuffle

### DIFF
--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -78,17 +78,7 @@ describe('MatchesTab display', () => {
     // screen.debug();
 
     const text = document.body.textContent || '';
-        codex/modifier-handleprint-pour-tous-les-types-de-tournoi
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
-        codex/modifier-conditionnel-pour-getgrouplabel
-    expect(text).toContain('1a - T1-A');
-    expect(text).toContain('2a - T2-A');
-
     expect(text).toContain('1 : A - T1-A');
     expect(text).toContain('2 : A - T2-A');
-        main
-        main
   });
 });

--- a/src/utils/__tests__/quadretteMatchmaking.test.ts
+++ b/src/utils/__tests__/quadretteMatchmaking.test.ts
@@ -71,6 +71,31 @@ describe('generateQuadretteMatches', () => {
     expect(tete!.team2Ids).toHaveLength(1);
   });
 
+  it('randomizes first round pairings so sequential teams are not always matched', () => {
+    const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
+    const tournament = baseTournament(teams);
+
+    const values = [0.4, 0.6, 0.3, 0.9, 0.2, 0.8, 0.1, 0.7];
+    const randomSpy = jest
+      .spyOn(Math, 'random')
+      .mockImplementation(() => values.shift() ?? 0.5);
+
+    const matches = generateMatches(tournament);
+    randomSpy.mockRestore();
+
+    const baseOrder = teams.map(t => t.id);
+    const pairs = Array.from(
+      new Set(matches.map(m => [m.team1Id, m.team2Id].sort().join('-')))
+    );
+
+    const hasSequential = pairs.some(p => {
+      const [t1, t2] = p.split('-');
+      const diff = Math.abs(baseOrder.indexOf(t1) - baseOrder.indexOf(t2));
+      return diff === 1;
+    });
+    expect(hasSequential).toBe(false);
+  });
+
   it('avoids pairing the same teams more than once', () => {
     const teams = [makeTeam('A'), makeTeam('B'), makeTeam('C'), makeTeam('D')];
     const tournament = baseTournament(teams);

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -183,6 +183,9 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
   });
 
   const remaining = [...teams];
+  if (round === 1) {
+    remaining.sort(() => Math.random() - 0.5);
+  }
   const pairings: [Team, Team][] = [];
 
   while (remaining.length > 1) {


### PR DESCRIPTION
## Summary
- randomize team order before quadrette pairings
- ensure quadrette pairing shuffle in tests
- clean up MatchesTab test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687186ed3c748324b47a080f5cedcc1b