### PR TITLE
Delay standings print until window loads

### DIFF
--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -95,7 +95,10 @@ export function StandingsTab({ teams }: StandingsTabProps) {
 
     printWindow.document.write(printContent);
     printWindow.document.close();
-    printWindow.print();
+    printWindow.onload = () => {
+      printWindow.focus();
+      printWindow.print();
+    };
   };
 
   return (


### PR DESCRIPTION
## Summary
- wait for standings print window to load before printing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3a131d083248ef5b024c7c33e0d