### PR TITLE
feat: add Electron HTML printing API

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,5 @@
 // electron/main.cjs
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
 
 function createWindow() {
@@ -21,7 +21,8 @@ function createWindow() {
       : path.join(appPath, 'public', 'logo.ico'),
     webPreferences: {
       contextIsolation: true,
-      nodeIntegration: false
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.cjs')
     }
   });
 
@@ -34,4 +35,15 @@ function createWindow() {
 
 app.whenReady().then(createWindow);
 app.on('window-all-closed', () => app.quit());
+
+ipcMain.handle('print-html', async (_event, html) => {
+  const printWindow = new BrowserWindow({ show: false });
+  await printWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
+  return new Promise((resolve) => {
+    printWindow.webContents.print({ silent: false }, () => {
+      printWindow.close();
+      resolve();
+    });
+  });
+});
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  printHtml: (html) => ipcRenderer.invoke('print-html', html)
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     },
     "files": [
       "dist/**/*",
-      "electron/main.cjs"
+      "electron/main.cjs",
+      "electron/preload.cjs"
     ],
     "win": {
       "icon": "public/logo.ico",

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -98,8 +98,6 @@ export function MatchesTab({
 
   const handlePrintRound = (round: number) => {
     const roundMatches = groupedMatches[round];
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
 
     const printContent = `
       <!DOCTYPE html>
@@ -161,12 +159,7 @@ export function MatchesTab({
       </html>
     `;
 
-    printWindow.document.write(printContent);
-    printWindow.document.close();
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-    };
+    window.electronAPI.printHtml(printContent);
   };
 
   const handleDeleteRound = (round: number) => {

--- a/src/components/PoolsTab.tsx
+++ b/src/components/PoolsTab.tsx
@@ -21,9 +21,6 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
   const [showCategoryB, setShowCategoryB] = useState(false);
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
-
     const printContent = `
       <!DOCTYPE html>
       <html>
@@ -61,9 +58,7 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
       </html>
     `;
 
-    printWindow.document.write(printContent);
-    printWindow.document.close();
-    printWindow.print();
+    window.electronAPI.printHtml(printContent);
   };
 
   const generatePoolHTML = (poolTeams: Team[]) => {
@@ -387,9 +382,6 @@ function FinalPhases({ qualifiedTeams, tournament, matches, onUpdateScore, onUpd
   );
 
   const handlePrintFinals = () => {
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
-
     const printContent = `
       <!DOCTYPE html>
       <html>
@@ -427,9 +419,7 @@ function FinalPhases({ qualifiedTeams, tournament, matches, onUpdateScore, onUpd
       </html>
     `;
 
-    printWindow.document.write(printContent);
-    printWindow.document.close();
-    printWindow.print();
+    window.electronAPI.printHtml(printContent);
   };
 
   return (

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -29,9 +29,6 @@ export function StandingsTab({ teams }: StandingsTabProps) {
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
-
     const printContent = `
       <!DOCTYPE html>
       <html>
@@ -93,12 +90,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
       </html>
     `;
 
-    printWindow.document.write(printContent);
-    printWindow.document.close();
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-    };
+    window.electronAPI.printHtml(printContent);
   };
 
   return (

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -32,9 +32,6 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam, onUpd
   };
 
   const handlePrint = () => {
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
-
     const twoColumns = teams.length > 25;
 
     const printContent = `
@@ -83,12 +80,7 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam, onUpd
       </html>
     `;
 
-    printWindow.document.write(printContent);
-    printWindow.document.close();
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-    };
+    window.electronAPI.printHtml(printContent);
   };
 
   return (

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ElectronAPI {
+  printHtml: (html: string) => Promise<void>;
+}
+
+interface Window {
+  electronAPI: ElectronAPI;
+}


### PR DESCRIPTION
## Summary
- expose `print-html` IPC handler and contextBridge API
- replace window.print usage with `electronAPI.printHtml`
- include preload script in build

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d9d58b648324820a76ce6e888173