### PR TITLE
Show print preview window

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -37,7 +37,7 @@ app.whenReady().then(createWindow);
 app.on('window-all-closed', () => app.quit());
 
 ipcMain.handle('print-html', async (_event, html) => {
-  const printWindow = new BrowserWindow({ show: false });
+  const printWindow = new BrowserWindow({ show: true });
   await printWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
   return new Promise((resolve) => {
     printWindow.webContents.print({ silent: false }, () => {


### PR DESCRIPTION
## Summary
- display Electron's print preview window when printing HTML

## Testing
- `npm test`
- `npm run lint`
- `node_modules/.bin/electron --no-sandbox .` (fails: Missing X server or $DISPLAY)


------
https://chatgpt.com/codex/tasks/task_e_68a7e20508b8832490b6951a96689765