### PR TITLE
Show preview window before printing

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -38,12 +38,16 @@ app.on('window-all-closed', () => app.quit());
 
 ipcMain.handle('print-html', async (_event, html) => {
   const printWindow = new BrowserWindow({ show: false });
-  await printWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-  return new Promise((resolve) => {
-    printWindow.webContents.print({ silent: false }, () => {
-      printWindow.close();
-      resolve();
-    });
+  await printWindow.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+  );
+
+  printWindow.once('ready-to-show', () => {
+    printWindow.show();
+    printWindow.webContents.print(
+      { silent: false, printBackground: true },
+      () => printWindow.close()
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- show a hidden BrowserWindow with the HTML to print and reveal it once ready
- trigger printing with background graphics and close the preview window afterward

## Testing
- `npm test`
- `npm run lint`
- `npm run start:electron` *(fails: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e2be1f1c8324810395d1516a8070