### PR TITLE
Display player numbers in melee group labels

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -49,20 +49,16 @@ export function MatchesTab({
   };
 
   const getGroupLabel = (ids: string[]) => {
-    const players: Player[] = [];
-    let teamNumber: number | undefined;
-
-    ids.forEach((id, idx) => {
-      const team = teams.find(t => t.id === id);
-      if (team) {
-        players.push(...team.players);
-        if (idx === 0) {
-          teamNumber = teams.indexOf(team) + 1;
+    return ids
+      .map((id) => {
+        const team = teams.find((t) => t.id === id);
+        if (!team) {
+          return isSolo ? 'Joueur inconnu' : 'Équipe inconnue';
         }
-      }
-    });
-
-    return formatPlayers(players, teamNumber);
+        const num = teams.indexOf(team) + 1;
+        return formatPlayers(team.players, num);
+      })
+      .join(' / ');
   };
 
   const handleEditScore = (match: Match) => {

--- a/src/components/__tests__/MatchesTabMelee.test.tsx
+++ b/src/components/__tests__/MatchesTabMelee.test.tsx
@@ -69,7 +69,7 @@ describe('MatchesTab melee display', () => {
     );
 
     const text = document.body.textContent || '';
-    expect(text).toContain('1 : A - Alice / B - Bob');
-    expect(text).toContain('3 : C - Clara / D - Dan');
+    expect(text).toContain('1 : A - Alice / 2 : B - Bob');
+    expect(text).toContain('3 : C - Clara / 4 : D - Dan');
   });
 });


### PR DESCRIPTION
## Summary
- number each player when displaying grouped match labels
- update melee match label tests for numbering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07bb3c71c8324863fc6625f16d5aa