### PR TITLE
feat: keep tournament selection highlighted on hover

### DIFF
--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -97,7 +97,7 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
                     key={tournamentType.value}
                     className={`glass-card flex flex-col p-6 cursor-pointer transition-all duration-300 ${
                       type === tournamentType.value
-                        ? 'bg-blue-500/30 border-white/40'
+                        ? 'bg-blue-500/30 border-white/40 hover:bg-blue-500/40 hover:border-white/50'
                         : 'hover:bg-white/10'
                     }`}
                   >


### PR DESCRIPTION
## Summary
- keep selected tournament type highlighted when hovering to show active state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07d1cdd508324807c68bf5df11f31