### PR TITLE
Handle print errors and notify renderer

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -36,7 +36,7 @@ function createWindow() {
 app.whenReady().then(createWindow);
 app.on('window-all-closed', () => app.quit());
 
-ipcMain.handle('print-html', async (_event, html) => {
+ipcMain.handle('print-html', async (event, html) => {
   const printWindow = new BrowserWindow({ show: false });
   await printWindow.loadURL(
     `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
@@ -44,10 +44,15 @@ ipcMain.handle('print-html', async (_event, html) => {
 
   printWindow.once('ready-to-show', () => {
     printWindow.show();
-    printWindow.webContents.print(
-      { silent: false, printBackground: true },
-      () => printWindow.close()
-    );
+    try {
+      printWindow.webContents.print(
+        { silent: false, printBackground: true },
+        () => printWindow.close()
+      );
+    } catch (err) {
+      event.sender.send('print-error', err.message);
+      printWindow.close();
+    }
   });
 });
 

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -1,0 +1,36 @@
+jest.mock('electron', () => {
+  const ipcMain = { handle: jest.fn() };
+  const app = {
+    isPackaged: false,
+    whenReady: () => Promise.resolve(),
+    on: jest.fn(),
+    quit: jest.fn(),
+    getAppPath: jest.fn(() => '')
+  };
+  const BrowserWindow = jest.fn().mockImplementation(() => ({
+    loadURL: jest.fn().mockResolvedValue(undefined),
+    once: jest.fn((event, cb) => cb()),
+    show: jest.fn(),
+    close: jest.fn(),
+    webContents: {
+      print: jest.fn(() => {
+        throw new Error('boom');
+      })
+    }
+  }));
+  return { ipcMain, app, BrowserWindow };
+});
+
+import { ipcMain } from 'electron';
+
+describe('print-html error handling', () => {
+  test('sends print-error when printing fails', async () => {
+    await import('./main.cjs');
+    const handler = ipcMain.handle.mock.calls.find(c => c[0] === 'print-html')[1];
+    const mockEvent = { sender: { send: jest.fn() } };
+
+    await handler(mockEvent, '<html></html>');
+
+    expect(mockEvent.sender.send).toHaveBeenCalledWith('print-error', 'boom');
+  });
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  printHtml: (html) => ipcRenderer.invoke('print-html', html)
+  printHtml: (html) => ipcRenderer.invoke('print-html', html),
+  onPrintError: (callback) => ipcRenderer.on('print-error', (_event, message) => callback(message))
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,12 @@ function App() {
     setAnimationsPaused(!animationsPaused);
   };
 
+  useEffect(() => {
+    window.electronAPI.onPrintError((message) => {
+      alert(`Erreur d'impression : ${message}`);
+    });
+  }, []);
+
   // Ensure the active tab is valid for the current tournament type
   useEffect(() => {
     if (!tournament) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ElectronAPI {
   printHtml: (html: string) => Promise<void>;
+  onPrintError: (callback: (message: string) => void) => void;
 }
 
 interface Window {


### PR DESCRIPTION
## Summary
- wrap `webContents.print` in try/catch and send `print-error` IPC message
- expose `onPrintError` listener in preload and react App to alert users
- add test ensuring print errors trigger renderer notifications

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0802539588324b740ef8d9928aae3