### PR TITLE
guard electron print error handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,9 +36,11 @@ function App() {
   };
 
   useEffect(() => {
-    window.electronAPI.onPrintError((message) => {
-      alert(`Erreur d'impression : ${message}`);
-    });
+    if (window.electronAPI?.onPrintError) {
+      window.electronAPI.onPrintError((message) => {
+        alert(`Erreur d'impression : ${message}`);
+      });
+    }
   }, []);
 
   // Ensure the active tab is valid for the current tournament type


### PR DESCRIPTION
## Summary
- check `window.electronAPI.onPrintError` exists before registering handler to prevent runtime errors in non-Electron browsers

## Testing
- `npm run lint`
- `npm test` *(fails: electron/main.test.ts — TypeError: printWindow.webContents.once is not a function)*
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68b082906f288324b0851b0aee86a452