### PR TITLE
feat: fallback to browser print

### DIFF
--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -13,6 +13,7 @@ jest.mock('electron', () => {
     show: jest.fn(),
     close: jest.fn(),
     webContents: {
+      once: jest.fn((event, cb) => cb()),
       print: jest.fn(() => {
         throw new Error('boom');
       })

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -154,7 +154,11 @@ export function MatchesTab({
     `;
 
     try {
-      await window.electronAPI.printHtml(printContent);
+      if (window.electronAPI?.printHtml) {
+        await window.electronAPI.printHtml(printContent);
+      } else {
+        window.print();
+      }
     } finally {
       setIsPrinting(false);
     }

--- a/src/components/PoolsTab.tsx
+++ b/src/components/PoolsTab.tsx
@@ -61,7 +61,11 @@ export function PoolsTab({ tournament, teams, pools, onGeneratePools, onUpdateSc
     `;
 
     try {
-      await window.electronAPI.printHtml(printContent);
+      if (window.electronAPI?.printHtml) {
+        await window.electronAPI.printHtml(printContent);
+      } else {
+        window.print();
+      }
     } finally {
       setIsPrinting(false);
     }
@@ -434,7 +438,11 @@ function FinalPhases({ qualifiedTeams, tournament, matches, onUpdateScore, onUpd
     `;
 
     try {
-      await window.electronAPI.printHtml(printContent);
+      if (window.electronAPI?.printHtml) {
+        await window.electronAPI.printHtml(printContent);
+      } else {
+        window.print();
+      }
     } finally {
       setIsPrinting(false);
     }

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -94,7 +94,11 @@ export function StandingsTab({ teams }: StandingsTabProps) {
     `;
 
     try {
-      await window.electronAPI.printHtml(printContent);
+      if (window.electronAPI?.printHtml) {
+        await window.electronAPI.printHtml(printContent);
+      } else {
+        window.print();
+      }
     } finally {
       setIsPrinting(false);
     }

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -83,7 +83,11 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam, onUpd
     `;
 
     try {
-      await window.electronAPI.printHtml(printContent);
+      if (window.electronAPI?.printHtml) {
+        await window.electronAPI.printHtml(printContent);
+      } else {
+        window.print();
+      }
     } finally {
       setIsPrinting(false);
     }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,5 +6,5 @@ interface ElectronAPI {
 }
 
 interface Window {
-  electronAPI: ElectronAPI;
+  electronAPI?: ElectronAPI;
 }


### PR DESCRIPTION
## Summary
- verify `window.electronAPI` exists before printing and fallback to `window.print`
- allow `window.electronAPI` to be undefined for browser environments
- fix electron tests to mock `webContents.once`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09827871c83248add6071e43a5952