### PR TITLE
ensure print-only window for matches

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -165,7 +165,14 @@ export function MatchesTab({
       if (window.electronAPI?.printHtml) {
         await window.electronAPI.printHtml(printContent);
       } else {
-        window.print();
+        const printWindow = window.open('', '_blank');
+        if (printWindow) {
+          printWindow.document.write(printContent);
+          printWindow.document.close();
+          printWindow.focus();
+          printWindow.print();
+          printWindow.close();
+        }
       }
     } finally {
       setIsPrinting(false);


### PR DESCRIPTION
## Summary
- print matches in a temporary window when Electron APIs are unavailable
- ensure print template retains centered heading and bordered table only

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1e46ad48324b817b1dd04b0564e