### PR TITLE
feat(matches): enable score editing by clicking on score

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -281,7 +281,9 @@ export function MatchesTab({
                   </tr>
                 </thead>
                 <tbody>
-                  {groupedMatches[round].map((match) => (
+                  {groupedMatches[round].map((match) => {
+                    const canEditScore = editingMatch !== match.id && !match.isBye;
+                    return (
                     <tr key={match.id} className="hover:bg-white/5 transition-colors">
                       <td className="w-1/12 px-2 py-4 whitespace-nowrap">
                         {match.isBye ? (
@@ -324,7 +326,19 @@ export function MatchesTab({
                             <span className="font-bold text-white">{getTeamDisplay(match.team1Id)}</span>
                           )}
                       </td>
-                      <td className="w-2/12 px-2 py-4 whitespace-nowrap text-center">
+                      <td
+                        className={`w-2/12 px-2 py-4 whitespace-nowrap text-center ${
+                          canEditScore ? 'cursor-pointer' : ''
+                        }`}
+                        onClick={canEditScore ? () => handleEditScore(match) : undefined}
+                        role={canEditScore ? 'button' : undefined}
+                        tabIndex={canEditScore ? 0 : undefined}
+                        onKeyDown={canEditScore ? (e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            handleEditScore(match);
+                          }
+                        } : undefined}
+                      >
                         {editingMatch === match.id ? (
                           <div className="flex items-center justify-center space-x-2">
                             <input
@@ -347,7 +361,9 @@ export function MatchesTab({
                           </div>
                         ) : (
                           <span className="text-2xl font-bold text-white">
-                            {match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}
+                            {match.completed || match.isBye
+                              ? `${match.team1Score} - ${match.team2Score}`
+                              : '- - -'}
                           </span>
                         )}
                       </td>
@@ -393,7 +409,8 @@ export function MatchesTab({
                         )}
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MatchesTab } from '../MatchesTab';
 import { Match, Team, Player } from '../../types/tournament';
@@ -68,4 +68,39 @@ describe('MatchesTab display', () => {
     expect(text).toContain('1 : A - T1-A');
     expect(text).toContain('2 : A - T2-A');
   });
+
+  it('enables score editing when clicking the score cell', () => {
+    const teams = [makeTeam('T1'), makeTeam('T2')];
+    const match: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'T1',
+      team2Id: 'T2',
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+
+    const { getByRole, getAllByRole } = render(
+      <MatchesTab
+        matches={[match]}
+        teams={teams}
+        currentRound={0}
+        courts={1}
+        onGenerateRound={() => {}}
+        onDeleteRound={() => {}}
+        onUpdateScore={() => {}}
+        onUpdateCourt={() => {}}
+      />
+    );
+
+    const scoreCell = getByRole('button', { name: '- - -' });
+    fireEvent.click(scoreCell);
+
+    const inputs = getAllByRole('spinbutton');
+    expect(inputs).toHaveLength(2);
+  });
 });
+


### PR DESCRIPTION
## Summary
- allow match score cell to trigger editing with keyboard and mouse, using accessible button semantics
- test score cell clicking to ensure inputs appear

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a75b0c3483248a292a5b70281db1