### PR TITLE
fix: use public path for logo

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -17,7 +17,7 @@ function createWindow() {
     width: 1024,
     height: 768,
     icon: app.isPackaged
-      ? path.join(process.resourcesPath, 'public', 'logo.ico')
+      ? path.join(process.resourcesPath, 'logo.ico')
       : path.join(appPath, 'public', 'logo.ico'),
     webPreferences: {
       contextIsolation: true,

--- a/landing.html
+++ b/landing.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pétanque Manager - Logiciel de gestion de tournois</title>
     <meta name="description" content="Pétanque Manager - Le logiciel professionnel pour organiser et gérer vos tournois de pétanque. Interface moderne, gestion des poules, phases finales automatiques.">
-    <link rel="icon" type="image/x-icon" href="./logo1.png">
+    <link rel="icon" type="image/x-icon" href="./public/logo1.png">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
@@ -14,7 +14,7 @@
     <nav class="navbar">
         <div class="nav-container">
             <div class="nav-brand">
-                <img src="./logo1.png" alt="Pétanque Manager" class="nav-logo">
+                <img src="./public/logo1.png" alt="Pétanque Manager" class="nav-logo">
                 <span class="nav-title">Pétanque Manager</span>
             </div>
             <div class="nav-menu" id="nav-menu">
@@ -524,7 +524,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-brand">
-                    <img src="./logo1.png" alt="Pétanque Manager" class="footer-logo">
+                    <img src="./public/logo1.png" alt="Pétanque Manager" class="footer-logo">
                     <h3>Pétanque Manager</h3>
                     <p>Le logiciel de référence pour vos tournois de pétanque</p>
                 </div>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "electron/main.cjs",
       "electron/preload.cjs"
     ],
+    "extraResources": [
+      "public/logo1.png",
+      "public/logo.ico"
+    ],
     "win": {
       "icon": "public/logo.ico",
       "target": [

--- a/script.js
+++ b/script.js
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Preload critical images
     const criticalImages = [
-        './logo1.png'
+        './public/logo1.png'
     ];
     
     criticalImages.forEach(src => {


### PR DESCRIPTION
## Summary
- load logo from public folder instead of bundling it
- update landing page and script references to use public logo path
- remove redundant asset file from source

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef599ab88324877ffc94e62a5619