### PR TITLE
feat: add validation button for score editing

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Match, Team, Player } from '../types/tournament';
-import { Play, Edit3, MapPin, Trophy, Printer, ChevronDown, Trash2, Loader2 } from 'lucide-react';
+import { Play, Edit3, MapPin, Printer, ChevronDown, Trash2, Loader2 } from 'lucide-react';
 
 interface MatchesTabProps {
   matches: Match[];
@@ -358,6 +358,12 @@ export function MatchesTab({
                               onChange={(e) => setEditScores({ ...editScores, team2: Number(e.target.value) })}
                               className="glass-input w-16 px-2 py-1 text-center font-bold"
                             />
+                            <button
+                              onClick={() => handleSaveScore(match.id)}
+                              className="glass-button px-2 py-1 text-sm font-bold"
+                            >
+                              Valider
+                            </button>
                           </div>
                         ) : (
                           <span className="text-2xl font-bold text-white">
@@ -380,22 +386,13 @@ export function MatchesTab({
                         {!match.isBye && (
                           <div className="flex justify-center space-x-2">
                             {editingMatch === match.id ? (
-                              <>
-                                <button
-                                  onClick={() => handleSaveScore(match.id)}
-                                  className="text-green-400 hover:text-green-300 transition-colors p-2 rounded-lg hover:bg-green-400/10"
-                                  title="Sauvegarder"
-                                >
-                                  <Trophy className="w-5 h-5" />
-                                </button>
-                                <button
-                                  onClick={handleCancelEdit}
-                                  className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-lg hover:bg-red-400/10 text-xl font-bold"
-                                  title="Annuler"
-                                >
-                                  ×
-                                </button>
-                              </>
+                              <button
+                                onClick={handleCancelEdit}
+                                className="text-red-400 hover:text-red-300 transition-colors p-2 rounded-lg hover:bg-red-400/10 text-xl font-bold"
+                                title="Annuler"
+                              >
+                                ×
+                              </button>
                             ) : (
                               <button
                                 onClick={() => handleEditScore(match)}

--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -101,6 +101,48 @@ describe('MatchesTab display', () => {
 
     const inputs = getAllByRole('spinbutton');
     expect(inputs).toHaveLength(2);
+    expect(getByRole('button', { name: 'Valider' })).toBeInTheDocument();
+  });
+
+  it('calls onUpdateScore when clicking Valider', () => {
+    const teams = [makeTeam('T1'), makeTeam('T2')];
+    const match: Match = {
+      id: 'm1',
+      round: 1,
+      court: 1,
+      team1Id: 'T1',
+      team2Id: 'T2',
+      completed: false,
+      isBye: false,
+      battleIntensity: 0,
+      hackingAttempts: 0,
+    };
+
+    const onUpdateScore = jest.fn();
+    const { getByRole, getAllByRole } = render(
+      <MatchesTab
+        matches={[match]}
+        teams={teams}
+        currentRound={0}
+        courts={1}
+        onGenerateRound={() => {}}
+        onDeleteRound={() => {}}
+        onUpdateScore={onUpdateScore}
+        onUpdateCourt={() => {}}
+      />
+    );
+
+    const scoreCell = getByRole('button', { name: '- - -' });
+    fireEvent.click(scoreCell);
+
+    const inputs = getAllByRole('spinbutton');
+    fireEvent.change(inputs[0], { target: { value: '13' } });
+    fireEvent.change(inputs[1], { target: { value: '7' } });
+
+    const saveButton = getByRole('button', { name: 'Valider' });
+    fireEvent.click(saveButton);
+
+    expect(onUpdateScore).toHaveBeenCalledWith('m1', 13, 7);
   });
 });
 


### PR DESCRIPTION
## Summary
- add inline "Valider" button when editing match scores
- remove redundant trophy save action
- test saving through new button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b229c010808324ab1f400416983f76