### PR TITLE
Prioritize wins when pairing later rounds

### DIFF
--- a/src/utils/__tests__/standardMatchmaking.test.ts
+++ b/src/utils/__tests__/standardMatchmaking.test.ts
@@ -1,5 +1,5 @@
 import { generateMatches } from '../matchmaking';
-import { Tournament, Team, Player } from '../../types/tournament';
+import { Tournament, Team, Player, Match } from '../../types/tournament';
 
 function makePlayer(id: string): Player {
   return {
@@ -94,5 +94,160 @@ describe('generateStandardMatches first round', () => {
       return diff === 1;
     });
     expect(hasSequential).toBe(false);
+  });
+});
+
+describe('generateStandardMatches advanced rounds', () => {
+  it('prioritizes wins over performance for later-round pairings', () => {
+    const teamA = makeTeam('A');
+    teamA.wins = 2;
+    teamA.losses = 0;
+    teamA.pointsFor = 26;
+    teamA.pointsAgainst = 12;
+    teamA.performance = 10;
+
+    const teamB = makeTeam('B');
+    teamB.wins = 2;
+    teamB.losses = 0;
+    teamB.pointsFor = 24;
+    teamB.pointsAgainst = 20;
+    teamB.performance = 5;
+
+    const teamC = makeTeam('C');
+    teamC.wins = 1;
+    teamC.losses = 1;
+    teamC.pointsFor = 30;
+    teamC.pointsAgainst = 25;
+    teamC.performance = 15;
+
+    const teamD = makeTeam('D');
+    teamD.wins = 0;
+    teamD.losses = 2;
+    teamD.pointsFor = 12;
+    teamD.pointsAgainst = 26;
+    teamD.performance = -5;
+
+    const teamE = makeTeam('E');
+    teamE.wins = 1;
+    teamE.losses = 1;
+    teamE.pointsFor = 22;
+    teamE.pointsAgainst = 24;
+    teamE.performance = 6;
+
+    const teamF = makeTeam('F');
+    teamF.wins = 0;
+    teamF.losses = 2;
+    teamF.pointsFor = 18;
+    teamF.pointsAgainst = 30;
+    teamF.performance = -8;
+
+    const teams = [teamA, teamB, teamC, teamD, teamE, teamF];
+
+    const previousMatches: Match[] = [
+      {
+        id: 'm1',
+        round: 1,
+        court: 1,
+        team1Id: 'A',
+        team2Id: 'C',
+        team1Score: 13,
+        team2Score: 7,
+        completed: true,
+        isBye: false,
+        battleIntensity: 42,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm2',
+        round: 1,
+        court: 2,
+        team1Id: 'B',
+        team2Id: 'D',
+        team1Score: 13,
+        team2Score: 9,
+        completed: true,
+        isBye: false,
+        battleIntensity: 43,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm3',
+        round: 1,
+        court: 3,
+        team1Id: 'E',
+        team2Id: 'F',
+        team1Score: 13,
+        team2Score: 12,
+        completed: true,
+        isBye: false,
+        battleIntensity: 44,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm4',
+        round: 2,
+        court: 1,
+        team1Id: 'A',
+        team2Id: 'E',
+        team1Score: 13,
+        team2Score: 8,
+        completed: true,
+        isBye: false,
+        battleIntensity: 45,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm5',
+        round: 2,
+        court: 2,
+        team1Id: 'B',
+        team2Id: 'F',
+        team1Score: 13,
+        team2Score: 7,
+        completed: true,
+        isBye: false,
+        battleIntensity: 46,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm6',
+        round: 2,
+        court: 3,
+        team1Id: 'C',
+        team2Id: 'D',
+        team1Score: 13,
+        team2Score: 10,
+        completed: true,
+        isBye: false,
+        battleIntensity: 47,
+        hackingAttempts: 0,
+      },
+    ];
+
+    const tournament: Tournament = {
+      ...baseTournament(teams),
+      currentRound: 2,
+      matches: previousMatches,
+    };
+
+    const matches = generateMatches(tournament);
+
+    expect(matches).toHaveLength(3);
+    expect(matches.every(match => !match.isBye)).toBe(true);
+
+    const hasMatch = (id1: string, id2: string) =>
+      matches.some(
+        match =>
+          !match.isBye &&
+          ((match.team1Id === id1 && match.team2Id === id2) || (match.team1Id === id2 && match.team2Id === id1))
+      );
+
+    expect(hasMatch('A', 'B')).toBe(true);
+    expect(hasMatch('C', 'A')).toBe(false);
+    expect(hasMatch('C', 'B')).toBe(false);
+
+    const cMatch = matches.find(match => match.team1Id === 'C' || match.team2Id === 'C');
+    expect(cMatch).toBeDefined();
+    expect([cMatch!.team1Id, cMatch!.team2Id].sort()).toEqual(['C', 'E']);
   });
 });

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -19,7 +19,20 @@ function generateStandardMatches(tournament: Tournament): Match[] {
   const remainingTeams =
     round === 1
       ? [...teams].sort(() => Math.random() - 0.5)
-      : [...teams].sort((a, b) => b.performance - a.performance);
+      : [...teams].sort((a, b) => {
+          if (b.wins !== a.wins) {
+            return b.wins - a.wins;
+          }
+          if (b.performance !== a.performance) {
+            return b.performance - a.performance;
+          }
+          const bPointDiff = b.pointsFor - b.pointsAgainst;
+          const aPointDiff = a.pointsFor - a.pointsAgainst;
+          if (bPointDiff !== aPointDiff) {
+            return bPointDiff - aPointDiff;
+          }
+          return a.name.localeCompare(b.name);
+        });
 
   const newMatches: Match[] = [];
 


### PR DESCRIPTION
## Summary
- sort standard-round matchmaking by win count before performance from the second round onward
- add a regression test ensuring late-round pairings stay within the same win bracket when possible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfcc3d4a08324afe29b971e5de6b7