### PR TITLE
Add license management backend and tests

### DIFF
--- a/api/license/__tests__/handlers.test.ts
+++ b/api/license/__tests__/handlers.test.ts
@@ -1,0 +1,165 @@
+/** @jest-environment node */
+
+import crypto from 'crypto';
+import { createDatabase } from '../../../db/client';
+import activateHandler from '../activate';
+import deactivateHandler from '../deactivate';
+import statusHandler from '../status';
+import { clearRateLimiter } from '../rateLimiter';
+import { createSignaturePayload, signLicensePayload } from '../../../lib/hmac';
+import { generateLicenseKey } from '../../../lib/licenseKey';
+
+const originalEnv = { ...process.env };
+
+function seedLicense(db: ReturnType<typeof createDatabase>, licenseKey: string, overrides?: { maxActivations?: number; reallocLimit?: number }) {
+  const accountId = crypto.randomUUID();
+  const licenseId = crypto.randomUUID();
+  db.prepare('INSERT INTO accounts (id, email, name) VALUES (?, ?, ?)').run(accountId, `${accountId}@example.com`, 'Test Account');
+  db
+    .prepare(
+      'INSERT INTO licenses (id, account_id, license_key, max_activations, monthly_reallocation_limit) VALUES (?, ?, ?, ?, ?)'
+    )
+    .run(
+      licenseId,
+      accountId,
+      licenseKey,
+      overrides?.maxActivations ?? 1,
+      overrides?.reallocLimit ?? 2
+    );
+  return { accountId, licenseId };
+}
+
+function signRequest(licenseKey: string, deviceId: string, nonce?: string) {
+  const payload = createSignaturePayload(licenseKey, deviceId, nonce);
+  return signLicensePayload(payload, process.env.LICENSE_SECRET ?? '');
+}
+
+beforeEach(() => {
+  clearRateLimiter();
+  Object.assign(process.env, originalEnv);
+  process.env.LICENSE_SECRET = 'test-secret';
+  process.env.MAX_ACTIVATIONS = '1';
+  process.env.MAX_REALLOCATIONS_PER_MONTH = '2';
+  process.env.RATE_LIMIT_MAX_REQUESTS = '100';
+  process.env.RATE_LIMIT_WINDOW_MS = '60000';
+});
+
+afterAll(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+describe('license API handlers', () => {
+  test('activates a license successfully', async () => {
+    const db = createDatabase(':memory:');
+    const licenseKey = generateLicenseKey(crypto.randomBytes);
+    seedLicense(db, licenseKey, { maxActivations: 2 });
+    const deviceId = 'device-1';
+    const signature = signRequest(licenseKey, deviceId);
+
+    const response = await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId, signature } },
+      { db }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ status: 'activated' });
+
+    const count = db.prepare('SELECT COUNT(*) as count FROM activations').get() as { count: number };
+    expect(count.count).toBe(1);
+    db.close();
+  });
+
+  test('rejects invalid license key', async () => {
+    const db = createDatabase(':memory:');
+    const response = await activateHandler(
+      { method: 'POST', body: { licenseKey: 'INVALID', deviceId: 'device-1', signature: 'bad' } },
+      { db }
+    );
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'INVALID_LICENSE_KEY' });
+    db.close();
+  });
+
+  test('refuses second activation when quota reached', async () => {
+    const db = createDatabase(':memory:');
+    const licenseKey = generateLicenseKey(crypto.randomBytes);
+    seedLicense(db, licenseKey, { maxActivations: 1 });
+    const signatureA = signRequest(licenseKey, 'device-1');
+    const signatureB = signRequest(licenseKey, 'device-2');
+
+    const first = await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-1', signature: signatureA } },
+      { db }
+    );
+    expect(first.status).toBe(200);
+
+    const second = await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-2', signature: signatureB } },
+      { db }
+    );
+    expect(second.status).toBe(409);
+    expect(second.body).toMatchObject({ error: 'ACTIVATION_LIMIT' });
+    db.close();
+  });
+
+  test('supports deactivation and reallocation within monthly limit', async () => {
+    const db = createDatabase(':memory:');
+    const licenseKey = generateLicenseKey(crypto.randomBytes);
+    seedLicense(db, licenseKey, { maxActivations: 1, reallocLimit: 2 });
+
+    const activationResponse = await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-1', signature: signRequest(licenseKey, 'device-1') } },
+      { db }
+    );
+    expect(activationResponse.status).toBe(200);
+
+    const deactivateResponse = await deactivateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-1', signature: signRequest(licenseKey, 'device-1') } },
+      { db }
+    );
+    expect(deactivateResponse.status).toBe(200);
+
+    const reactivation = await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-2', signature: signRequest(licenseKey, 'device-2') } },
+      { db }
+    );
+    expect(reactivation.status).toBe(200);
+    expect(reactivation.body).toMatchObject({ status: 'activated' });
+
+    const status = await statusHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-2', signature: signRequest(licenseKey, 'device-2') } },
+      { db }
+    );
+    expect(status.status).toBe(200);
+    expect(status.body).toMatchObject({ activations: 1, reallocationsThisMonth: 1 });
+    db.close();
+  });
+
+  test('prevents deactivation when monthly reallocation limit is exceeded', async () => {
+    const db = createDatabase(':memory:');
+    const licenseKey = generateLicenseKey(crypto.randomBytes);
+    seedLicense(db, licenseKey, { maxActivations: 1, reallocLimit: 1 });
+
+    await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-1', signature: signRequest(licenseKey, 'device-1') } },
+      { db }
+    );
+    await deactivateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-1', signature: signRequest(licenseKey, 'device-1') } },
+      { db }
+    );
+    await activateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-2', signature: signRequest(licenseKey, 'device-2') } },
+      { db }
+    );
+
+    const blocked = await deactivateHandler(
+      { method: 'POST', body: { licenseKey, deviceId: 'device-2', signature: signRequest(licenseKey, 'device-2') } },
+      { db }
+    );
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toMatchObject({ error: 'REALLOCATION_LIMIT' });
+    db.close();
+  });
+});

--- a/api/license/activate.ts
+++ b/api/license/activate.ts
@@ -1,0 +1,104 @@
+import type { SqliteDatabase } from '../../db/client';
+import { getSharedDatabase } from '../../db/client';
+import { consumeToken } from './rateLimiter';
+import { activateLicense, LicenseServiceError } from './service';
+import { getLicenseRuntimeConfig } from './config';
+import type { ActivationPayload, LicenseApiRequest, LicenseApiResponse } from './types';
+
+interface HandlerOptions {
+  db?: SqliteDatabase;
+}
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function buildRateLimiterId(req: LicenseApiRequest<ActivationPayload>): string {
+  const licenseKey = coerceString(req.body?.licenseKey) ?? 'unknown';
+  const ip = req.ip ?? (typeof req.headers?.['x-forwarded-for'] === 'string' ? req.headers?.['x-forwarded-for'] : 'unknown');
+  return `activate:${ip}:${licenseKey}`;
+}
+
+export async function handler(
+  req: LicenseApiRequest<ActivationPayload>,
+  options: HandlerOptions = {}
+): Promise<LicenseApiResponse> {
+  const runtimeConfig = getLicenseRuntimeConfig();
+  const db = options.db ?? getSharedDatabase();
+
+  if (req.method && req.method !== 'POST') {
+    return { status: 405, body: { error: 'METHOD_NOT_ALLOWED' } };
+  }
+
+  const licenseKey = coerceString(req.body?.licenseKey);
+  const deviceId = coerceString(req.body?.deviceId);
+  const signature = coerceString(req.body?.signature);
+  const nonce = coerceString(req.body?.nonce);
+
+  if (!licenseKey || !deviceId || !signature) {
+    return { status: 400, body: { error: 'INVALID_REQUEST', message: 'licenseKey, deviceId and signature are required' } };
+  }
+
+  const rateId = buildRateLimiterId(req);
+  const rateResult = consumeToken(rateId, {
+    limit: runtimeConfig.rateLimitMaxRequests,
+    windowMs: runtimeConfig.rateLimitWindowMs,
+  });
+  if (!rateResult.allowed) {
+    return {
+      status: 429,
+      body: {
+        error: 'RATE_LIMITED',
+        retryAfterMs: rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs,
+      },
+      headers: {
+        'Retry-After': Math.ceil((rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs) / 1000).toString(),
+      },
+    };
+  }
+
+  try {
+    const result = activateLicense(
+      { db },
+      {
+        licenseKey: licenseKey.toUpperCase(),
+        deviceId,
+        signature,
+        nonce: nonce ?? undefined,
+      }
+    );
+    return {
+      status: 200,
+      body: {
+        status: result.status,
+        activation: {
+          deviceId: result.activation.device_id,
+          firstActivatedAt: result.activation.first_activated_at,
+          lastActivatedAt: result.activation.last_activated_at,
+        },
+        ...(result.status === 'activated'
+          ? { remainingActivations: result.remainingActivations }
+          : {}),
+      },
+    };
+  } catch (error) {
+    if (error instanceof LicenseServiceError) {
+      return {
+        status: error.status,
+        body: {
+          error: error.code,
+          message: error.message,
+        },
+      };
+    }
+    return {
+      status: 500,
+      body: { error: 'UNEXPECTED_ERROR' },
+    };
+  }
+}
+
+export default handler;

--- a/api/license/config.ts
+++ b/api/license/config.ts
@@ -1,0 +1,35 @@
+const DEFAULT_MAX_ACTIVATIONS = 1;
+const DEFAULT_MONTHLY_REALLOCATIONS = 1;
+const DEFAULT_RATE_LIMIT_MAX = 10;
+const DEFAULT_RATE_LIMIT_WINDOW = 60_000;
+
+function readNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+export interface LicenseRuntimeConfig {
+  secret: string;
+  maxActivations: number;
+  monthlyReallocationLimit: number;
+  rateLimitMaxRequests: number;
+  rateLimitWindowMs: number;
+}
+
+export function getLicenseRuntimeConfig(): LicenseRuntimeConfig {
+  const secret = process.env.LICENSE_SECRET ?? '';
+  return {
+    secret,
+    maxActivations: readNumberEnv('MAX_ACTIVATIONS', DEFAULT_MAX_ACTIVATIONS),
+    monthlyReallocationLimit: readNumberEnv('MAX_REALLOCATIONS_PER_MONTH', DEFAULT_MONTHLY_REALLOCATIONS),
+    rateLimitMaxRequests: readNumberEnv('RATE_LIMIT_MAX_REQUESTS', DEFAULT_RATE_LIMIT_MAX),
+    rateLimitWindowMs: readNumberEnv('RATE_LIMIT_WINDOW_MS', DEFAULT_RATE_LIMIT_WINDOW),
+  };
+}

--- a/api/license/deactivate.ts
+++ b/api/license/deactivate.ts
@@ -1,0 +1,95 @@
+import type { SqliteDatabase } from '../../db/client';
+import { getSharedDatabase } from '../../db/client';
+import { consumeToken } from './rateLimiter';
+import { deactivateLicense, LicenseServiceError } from './service';
+import { getLicenseRuntimeConfig } from './config';
+import type { DeactivationPayload, LicenseApiRequest, LicenseApiResponse } from './types';
+
+interface HandlerOptions {
+  db?: SqliteDatabase;
+}
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function buildRateLimiterId(req: LicenseApiRequest<DeactivationPayload>): string {
+  const rawKey = req.body?.licenseKey;
+  const licenseKey = coerceString(Array.isArray(rawKey) ? rawKey[0] : rawKey) ?? 'unknown';
+  const forwarded = req.headers?.['x-forwarded-for'];
+  const ip = req.ip ?? (typeof forwarded === 'string' ? forwarded : Array.isArray(forwarded) ? forwarded[0] : 'unknown');
+  return `deactivate:${ip}:${licenseKey}`;
+}
+
+export async function handler(
+  req: LicenseApiRequest<DeactivationPayload>,
+  options: HandlerOptions = {}
+): Promise<LicenseApiResponse> {
+  const runtimeConfig = getLicenseRuntimeConfig();
+  const db = options.db ?? getSharedDatabase();
+
+  if (req.method && !['POST', 'DELETE'].includes(req.method)) {
+    return { status: 405, body: { error: 'METHOD_NOT_ALLOWED' } };
+  }
+
+  const licenseKey = coerceString(req.body?.licenseKey);
+  const deviceId = coerceString(req.body?.deviceId);
+  const signature = coerceString(req.body?.signature);
+  const nonce = coerceString(req.body?.nonce);
+
+  if (!licenseKey || !deviceId || !signature) {
+    return { status: 400, body: { error: 'INVALID_REQUEST', message: 'licenseKey, deviceId and signature are required' } };
+  }
+
+  const rateResult = consumeToken(buildRateLimiterId(req), {
+    limit: runtimeConfig.rateLimitMaxRequests,
+    windowMs: runtimeConfig.rateLimitWindowMs,
+  });
+  if (!rateResult.allowed) {
+    return {
+      status: 429,
+      body: {
+        error: 'RATE_LIMITED',
+        retryAfterMs: rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs,
+      },
+      headers: {
+        'Retry-After': Math.ceil((rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs) / 1000).toString(),
+      },
+    };
+  }
+
+  try {
+    const result = deactivateLicense(
+      { db },
+      {
+        licenseKey: licenseKey.toUpperCase(),
+        deviceId,
+        signature,
+        nonce: nonce ?? undefined,
+      }
+    );
+    return {
+      status: 200,
+      body: {
+        status: result.status,
+        remainingReallocations: result.remainingReallocations,
+      },
+    };
+  } catch (error) {
+    if (error instanceof LicenseServiceError) {
+      return {
+        status: error.status,
+        body: {
+          error: error.code,
+          message: error.message,
+        },
+      };
+    }
+    return { status: 500, body: { error: 'UNEXPECTED_ERROR' } };
+  }
+}
+
+export default handler;

--- a/api/license/rateLimiter.ts
+++ b/api/license/rateLimiter.ts
@@ -1,0 +1,37 @@
+interface RateLimiterOptions {
+  limit: number;
+  windowMs: number;
+}
+
+interface RateState {
+  count: number;
+  expiresAt: number;
+}
+
+const buckets = new Map<string, RateState>();
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfterMs?: number;
+}
+
+export function consumeToken(identifier: string, options: RateLimiterOptions): RateLimitResult {
+  const now = Date.now();
+  const existing = buckets.get(identifier);
+  if (!existing || existing.expiresAt <= now) {
+    buckets.set(identifier, { count: 1, expiresAt: now + options.windowMs });
+    return { allowed: true, remaining: options.limit - 1 };
+  }
+
+  if (existing.count >= options.limit) {
+    return { allowed: false, remaining: 0, retryAfterMs: existing.expiresAt - now };
+  }
+
+  existing.count += 1;
+  return { allowed: true, remaining: Math.max(options.limit - existing.count, 0) };
+}
+
+export function clearRateLimiter() {
+  buckets.clear();
+}

--- a/api/license/repository.ts
+++ b/api/license/repository.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'crypto';
+import type { SqliteDatabase } from '../../db/client';
+import type { ActivationRecord, LicenseRecord } from './types';
+
+export function findLicenseByKey(db: SqliteDatabase, licenseKey: string): LicenseRecord | undefined {
+  return db.prepare<unknown[], LicenseRecord>('SELECT * FROM licenses WHERE license_key = ?').get(licenseKey);
+}
+
+export function listActivations(db: SqliteDatabase, licenseId: string): ActivationRecord[] {
+  return db
+    .prepare<unknown[], ActivationRecord>('SELECT * FROM activations WHERE license_id = ? ORDER BY last_activated_at DESC')
+    .all(licenseId);
+}
+
+export function findActivation(db: SqliteDatabase, licenseId: string, deviceId: string): ActivationRecord | undefined {
+  return db
+    .prepare<unknown[], ActivationRecord>('SELECT * FROM activations WHERE license_id = ? AND device_id = ?')
+    .get(licenseId, deviceId);
+}
+
+export function countActivations(db: SqliteDatabase, licenseId: string): number {
+  const row = db.prepare('SELECT COUNT(*) as count FROM activations WHERE license_id = ?').get(licenseId) as { count: number };
+  return row?.count ?? 0;
+}
+
+export function touchActivation(db: SqliteDatabase, activationId: string, timestamp: Date) {
+  db.prepare('UPDATE activations SET last_activated_at = ? WHERE id = ?').run(timestamp.toISOString(), activationId);
+}
+
+export function insertActivation(db: SqliteDatabase, licenseId: string, deviceId: string, timestamp: Date): ActivationRecord {
+  const id = randomUUID();
+  db
+    .prepare('INSERT INTO activations (id, license_id, device_id, first_activated_at, last_activated_at) VALUES (?, ?, ?, ?, ?)')
+    .run(id, licenseId, deviceId, timestamp.toISOString(), timestamp.toISOString());
+  return {
+    id,
+    license_id: licenseId,
+    device_id: deviceId,
+    first_activated_at: timestamp.toISOString(),
+    last_activated_at: timestamp.toISOString(),
+  };
+}
+
+export function deleteActivation(db: SqliteDatabase, licenseId: string, deviceId: string): boolean {
+  const result = db.prepare('DELETE FROM activations WHERE license_id = ? AND device_id = ?').run(licenseId, deviceId);
+  return result.changes > 0;
+}
+
+export function logReallocation(db: SqliteDatabase, licenseId: string, deviceId: string, timestamp: Date) {
+  const id = randomUUID();
+  db
+    .prepare('INSERT INTO realloc_logs (id, license_id, device_id, created_at) VALUES (?, ?, ?, ?)')
+    .run(id, licenseId, deviceId, timestamp.toISOString());
+}
+
+function startOfMonth(date: Date): string {
+  const monthStart = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1, 0, 0, 0, 0));
+  return monthStart.toISOString();
+}
+
+export function countReallocationsThisMonth(db: SqliteDatabase, licenseId: string, now: Date): number {
+  const row = db
+    .prepare(
+      'SELECT COUNT(*) as count FROM realloc_logs WHERE license_id = ? AND created_at >= ?'
+    )
+    .get(licenseId, startOfMonth(now)) as { count: number };
+  return row?.count ?? 0;
+}

--- a/api/license/service.ts
+++ b/api/license/service.ts
@@ -1,0 +1,151 @@
+import { isValidLicenseKey } from '../../lib/licenseKey';
+import { createSignaturePayload, verifySignature } from '../../lib/hmac';
+import { getLicenseRuntimeConfig } from './config';
+import {
+  countActivations,
+  countReallocationsThisMonth,
+  deleteActivation,
+  findActivation,
+  findLicenseByKey,
+  insertActivation,
+  listActivations,
+  logReallocation,
+  touchActivation,
+} from './repository';
+import type {
+  ActivationPayload,
+  DeactivationPayload,
+  LicenseServiceContext,
+  LicenseStatus,
+  StatusPayload,
+} from './types';
+
+export class LicenseServiceError extends Error {
+  constructor(message: string, public code: string, public status: number) {
+    super(message);
+  }
+}
+
+function requireSecret(secret: string) {
+  if (!secret) {
+    throw new LicenseServiceError('LICENSE_SECRET is not configured', 'MISSING_SECRET', 500);
+  }
+}
+
+function ensureValidLicenseKey(licenseKey: string) {
+  if (!isValidLicenseKey(licenseKey)) {
+    throw new LicenseServiceError('Invalid license key format', 'INVALID_LICENSE_KEY', 400);
+  }
+}
+
+function assertSignature(licenseKey: string, deviceId: string, signature: string, secret: string, nonce?: string) {
+  const payload = createSignaturePayload(licenseKey, deviceId, nonce);
+  const valid = verifySignature(payload, signature, secret);
+  if (!valid) {
+    throw new LicenseServiceError('Signature verification failed', 'INVALID_SIGNATURE', 401);
+  }
+}
+
+function resolveMaxActivations(recordValue: number, fallback: number): number {
+  if (recordValue && recordValue > 0) {
+    return recordValue;
+  }
+  return fallback;
+}
+
+function resolveMonthlyLimit(recordValue: number, fallback: number): number {
+  if (recordValue && recordValue > 0) {
+    return recordValue;
+  }
+  return fallback;
+}
+
+export function activateLicense(ctx: LicenseServiceContext, payload: ActivationPayload) {
+  const config = getLicenseRuntimeConfig();
+  requireSecret(config.secret);
+  ensureValidLicenseKey(payload.licenseKey);
+  const license = findLicenseByKey(ctx.db, payload.licenseKey);
+  if (!license) {
+    throw new LicenseServiceError('License not found', 'LICENSE_NOT_FOUND', 404);
+  }
+  assertSignature(payload.licenseKey, payload.deviceId, payload.signature, config.secret, payload.nonce);
+  const now = ctx.now?.() ?? new Date();
+  const existing = findActivation(ctx.db, license.id, payload.deviceId);
+  if (existing) {
+    touchActivation(ctx.db, existing.id, now);
+    return {
+      status: 'already_active' as const,
+      activation: {
+        ...existing,
+        last_activated_at: now.toISOString(),
+      },
+    };
+  }
+
+  const maxActivations = resolveMaxActivations(license.max_activations, config.maxActivations);
+  const currentActivations = countActivations(ctx.db, license.id);
+  if (currentActivations >= maxActivations) {
+    throw new LicenseServiceError('Activation quota reached', 'ACTIVATION_LIMIT', 409);
+  }
+
+  const activation = insertActivation(ctx.db, license.id, payload.deviceId, now);
+  return {
+    status: 'activated' as const,
+    activation,
+    remainingActivations: Math.max(maxActivations - (currentActivations + 1), 0),
+  };
+}
+
+export function getLicenseStatus(ctx: LicenseServiceContext, payload: StatusPayload): LicenseStatus {
+  const config = getLicenseRuntimeConfig();
+  requireSecret(config.secret);
+  ensureValidLicenseKey(payload.licenseKey);
+  const license = findLicenseByKey(ctx.db, payload.licenseKey);
+  if (!license) {
+    throw new LicenseServiceError('License not found', 'LICENSE_NOT_FOUND', 404);
+  }
+  assertSignature(payload.licenseKey, payload.deviceId, payload.signature, config.secret, payload.nonce);
+  const now = ctx.now?.() ?? new Date();
+  const activations = listActivations(ctx.db, license.id);
+  const maxActivations = resolveMaxActivations(license.max_activations, config.maxActivations);
+  const reallocations = countReallocationsThisMonth(ctx.db, license.id, now);
+  return {
+    licenseKey: license.license_key,
+    activations: activations.length,
+    maxActivations,
+    devices: activations.map((activation) => ({
+      deviceId: activation.device_id,
+      lastSeen: activation.last_activated_at,
+    })),
+    reallocationsThisMonth: reallocations,
+    monthlyReallocationLimit: resolveMonthlyLimit(license.monthly_reallocation_limit, config.monthlyReallocationLimit),
+    isActiveOnDevice: activations.some((activation) => activation.device_id === payload.deviceId),
+  };
+}
+
+export function deactivateLicense(ctx: LicenseServiceContext, payload: DeactivationPayload) {
+  const config = getLicenseRuntimeConfig();
+  requireSecret(config.secret);
+  ensureValidLicenseKey(payload.licenseKey);
+  const license = findLicenseByKey(ctx.db, payload.licenseKey);
+  if (!license) {
+    throw new LicenseServiceError('License not found', 'LICENSE_NOT_FOUND', 404);
+  }
+  assertSignature(payload.licenseKey, payload.deviceId, payload.signature, config.secret, payload.nonce);
+  const activation = findActivation(ctx.db, license.id, payload.deviceId);
+  if (!activation) {
+    throw new LicenseServiceError('Activation not found for device', 'ACTIVATION_NOT_FOUND', 404);
+  }
+  const now = ctx.now?.() ?? new Date();
+  const limit = resolveMonthlyLimit(license.monthly_reallocation_limit, config.monthlyReallocationLimit);
+  const reallocations = countReallocationsThisMonth(ctx.db, license.id, now);
+  if (reallocations >= limit) {
+    throw new LicenseServiceError('Monthly reallocation limit reached', 'REALLOCATION_LIMIT', 429);
+  }
+  deleteActivation(ctx.db, license.id, payload.deviceId);
+  logReallocation(ctx.db, license.id, payload.deviceId, now);
+  return {
+    status: 'deactivated' as const,
+    remainingReallocations: Math.max(limit - (reallocations + 1), 0),
+  };
+}

--- a/api/license/status.ts
+++ b/api/license/status.ts
@@ -1,0 +1,92 @@
+import type { SqliteDatabase } from '../../db/client';
+import { getSharedDatabase } from '../../db/client';
+import { consumeToken } from './rateLimiter';
+import { getLicenseRuntimeConfig } from './config';
+import { getLicenseStatus as getLicenseStatusService, LicenseServiceError } from './service';
+import type { LicenseApiRequest, LicenseApiResponse, StatusPayload } from './types';
+
+interface HandlerOptions {
+  db?: SqliteDatabase;
+}
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function buildRateLimiterId(req: LicenseApiRequest<StatusPayload>): string {
+  const rawKey = req.body?.licenseKey ?? req.query?.licenseKey;
+  const licenseKey = coerceString(Array.isArray(rawKey) ? rawKey[0] : rawKey) ?? 'unknown';
+  const forwarded = req.headers?.['x-forwarded-for'];
+  const ip = req.ip ?? (typeof forwarded === 'string' ? forwarded : Array.isArray(forwarded) ? forwarded[0] : 'unknown');
+  return `status:${ip}:${licenseKey}`;
+}
+
+export async function handler(
+  req: LicenseApiRequest<StatusPayload>,
+  options: HandlerOptions = {}
+): Promise<LicenseApiResponse> {
+  const runtimeConfig = getLicenseRuntimeConfig();
+  const db = options.db ?? getSharedDatabase();
+
+  if (req.method && !['POST', 'GET'].includes(req.method)) {
+    return { status: 405, body: { error: 'METHOD_NOT_ALLOWED' } };
+  }
+
+  const licenseKey = coerceString(req.body?.licenseKey ?? (req.query?.licenseKey as string | undefined));
+  const deviceId = coerceString(req.body?.deviceId ?? (req.query?.deviceId as string | undefined));
+  const signature = coerceString(req.body?.signature ?? (req.query?.signature as string | undefined));
+  const nonce = coerceString(req.body?.nonce ?? (req.query?.nonce as string | undefined));
+
+  if (!licenseKey || !deviceId || !signature) {
+    return { status: 400, body: { error: 'INVALID_REQUEST', message: 'licenseKey, deviceId and signature are required' } };
+  }
+
+  const rateResult = consumeToken(buildRateLimiterId(req), {
+    limit: runtimeConfig.rateLimitMaxRequests,
+    windowMs: runtimeConfig.rateLimitWindowMs,
+  });
+  if (!rateResult.allowed) {
+    return {
+      status: 429,
+      body: {
+        error: 'RATE_LIMITED',
+        retryAfterMs: rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs,
+      },
+      headers: {
+        'Retry-After': Math.ceil((rateResult.retryAfterMs ?? runtimeConfig.rateLimitWindowMs) / 1000).toString(),
+      },
+    };
+  }
+
+  try {
+    const status = getLicenseStatusService(
+      { db },
+      {
+        licenseKey: licenseKey.toUpperCase(),
+        deviceId,
+        signature,
+        nonce: nonce ?? undefined,
+      }
+    );
+    return {
+      status: 200,
+      body: status,
+    };
+  } catch (error) {
+    if (error instanceof LicenseServiceError) {
+      return {
+        status: error.status,
+        body: {
+          error: error.code,
+          message: error.message,
+        },
+      };
+    }
+    return { status: 500, body: { error: 'UNEXPECTED_ERROR' } };
+  }
+}
+
+export default handler;

--- a/api/license/types.ts
+++ b/api/license/types.ts
@@ -1,0 +1,64 @@
+import type { SqliteDatabase } from '../../db/client';
+
+export interface LicenseApiRequest<TBody = unknown> {
+  method?: string;
+  ip?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  body?: TBody;
+  query?: Record<string, string | string[]>;
+}
+
+export interface LicenseApiResponse<TBody = unknown> {
+  status: number;
+  body: TBody;
+  headers?: Record<string, string>;
+}
+
+export interface LicenseRecord {
+  id: string;
+  account_id: string;
+  license_key: string;
+  max_activations: number;
+  monthly_reallocation_limit: number;
+  created_at: string;
+  expires_at?: string | null;
+}
+
+export interface ActivationRecord {
+  id: string;
+  license_id: string;
+  device_id: string;
+  first_activated_at: string;
+  last_activated_at: string;
+}
+
+export interface LicenseServiceContext {
+  db: SqliteDatabase;
+  now?: () => Date;
+}
+
+export interface ActivationPayload {
+  licenseKey: string;
+  deviceId: string;
+  signature: string;
+  nonce?: string;
+}
+
+export type DeactivationPayload = ActivationPayload;
+
+export interface StatusPayload {
+  licenseKey: string;
+  deviceId: string;
+  signature: string;
+  nonce?: string;
+}
+
+export interface LicenseStatus {
+  licenseKey: string;
+  activations: number;
+  maxActivations: number;
+  devices: { deviceId: string; lastSeen: string }[];
+  reallocationsThisMonth: number;
+  monthlyReallocationLimit: number;
+  isActiveOnDevice: boolean;
+}

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import DatabaseConstructor from 'better-sqlite3';
+import type { Database } from 'better-sqlite3';
+
+export type SqliteDatabase = Database;
+
+let sharedDb: SqliteDatabase | undefined;
+let sharedDbPath: string | undefined;
+
+const SCHEMA_PATH = path.join(__dirname, 'schema.sql');
+
+function applyMigrations(db: SqliteDatabase) {
+  const schemaSql = fs.readFileSync(SCHEMA_PATH, 'utf8');
+  db.exec(schemaSql);
+}
+
+export function createDatabase(filename: string = process.env.DATABASE_URL ?? ':memory:'): SqliteDatabase {
+  const db = new DatabaseConstructor(filename);
+  db.pragma('foreign_keys = ON');
+  applyMigrations(db);
+  return db;
+}
+
+export function getSharedDatabase(): SqliteDatabase {
+  const targetPath = process.env.DATABASE_URL ?? 'licenses.sqlite';
+  if (!sharedDb || sharedDbPath !== targetPath) {
+    if (sharedDb) {
+      sharedDb.close();
+    }
+    sharedDb = createDatabase(targetPath);
+    sharedDbPath = targetPath;
+  }
+  return sharedDb;
+}
+
+export function resetSharedDatabase() {
+  if (sharedDb) {
+    sharedDb.close();
+  }
+  sharedDb = undefined;
+  sharedDbPath = undefined;
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,41 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS licenses (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  license_key TEXT NOT NULL UNIQUE,
+  max_activations INTEGER NOT NULL,
+  monthly_reallocation_limit INTEGER NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  expires_at DATETIME,
+  FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS activations (
+  id TEXT PRIMARY KEY,
+  license_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  first_activated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  last_activated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (license_id) REFERENCES licenses(id) ON DELETE CASCADE,
+  UNIQUE (license_id, device_id)
+);
+
+CREATE TABLE IF NOT EXISTS realloc_logs (
+  id TEXT PRIMARY KEY,
+  license_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (license_id) REFERENCES licenses(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_license_key ON licenses(license_key);
+CREATE INDEX IF NOT EXISTS idx_activations_license ON activations(license_id);
+CREATE INDEX IF NOT EXISTS idx_realloc_logs_license_created ON realloc_logs(license_id, created_at);

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,9 +4,7 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.app.json',
-    },
+  transform: {
+    '^.+\\.(t|j)sx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },
 };

--- a/lib/__tests__/licenseKey.test.ts
+++ b/lib/__tests__/licenseKey.test.ts
@@ -1,0 +1,51 @@
+/** @jest-environment node */
+
+import crypto from 'crypto';
+import {
+  calculateLicenseChecksum,
+  generateLicenseKey,
+  isValidLicenseKey,
+  maskLicenseKey,
+  normalizeLicenseKey,
+} from '../licenseKey';
+import { createSignaturePayload, signLicensePayload, verifySignature } from '../hmac';
+
+describe('license key utilities', () => {
+  test('generateLicenseKey produces a valid key with checksum', () => {
+    const key = generateLicenseKey(crypto.randomBytes);
+    expect(key).toMatch(/^PM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(isValidLicenseKey(key)).toBe(true);
+  });
+
+    test('normalizeLicenseKey removes extraneous characters', () => {
+      expect(normalizeLicenseKey('pm-abcd-efgh-jklm')).toBe('PMABCDEFGHJKLM');
+    });
+
+  test('calculateLicenseChecksum is deterministic', () => {
+    const payload = 'PMABCDEFGHJKLM';
+    const checksum = calculateLicenseChecksum(payload);
+    expect(checksum).toHaveLength(1);
+    expect(calculateLicenseChecksum(payload)).toBe(checksum);
+  });
+
+  test('isValidLicenseKey rejects keys with wrong checksum', () => {
+    const key = generateLicenseKey(crypto.randomBytes);
+    const tampered = key.replace(/.$/, (char) => (char === 'A' ? 'B' : 'A'));
+    expect(isValidLicenseKey(tampered)).toBe(false);
+  });
+
+  test('maskLicenseKey redacts middle segments', () => {
+    const key = generateLicenseKey(crypto.randomBytes);
+    const masked = maskLicenseKey(key);
+    const segments = key.split('-');
+    expect(masked).toBe(`PM-XXXX-XXXX-${segments[3]}`);
+  });
+
+  test('HMAC utilities produce verifiable signatures', () => {
+    const payload = createSignaturePayload('PM-1234-5678-9ABC', 'device-1');
+    const secret = 'super-secret';
+    const signature = signLicensePayload(payload, secret);
+    expect(verifySignature(payload, signature, secret)).toBe(true);
+    expect(verifySignature(payload, signature.slice(0, -1) + '0', secret)).toBe(false);
+  });
+});

--- a/lib/hmac.ts
+++ b/lib/hmac.ts
@@ -1,0 +1,36 @@
+import crypto from 'crypto';
+
+export function createSignaturePayload(licenseKey: string, deviceId: string, nonce?: string): string {
+  if (!licenseKey || !deviceId) {
+    throw new Error('licenseKey and deviceId are required to build signature payload');
+  }
+  const normalizedNonce = nonce ? `:${nonce}` : '';
+  return `${licenseKey}:${deviceId}${normalizedNonce}`;
+}
+
+export function signLicensePayload(payload: string, secret: string): string {
+  if (!secret) {
+    throw new Error('Missing LICENSE_SECRET environment variable');
+  }
+  return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+export function verifySignature(payload: string, signature: string, secret: string): boolean {
+  if (!secret) {
+    return false;
+  }
+  if (!signature) {
+    return false;
+  }
+  const expected = signLicensePayload(payload, secret);
+  try {
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const providedBuffer = Buffer.from(signature, 'hex');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
+  } catch {
+    return false;
+  }
+}

--- a/lib/licenseKey.ts
+++ b/lib/licenseKey.ts
@@ -1,0 +1,85 @@
+import crypto from 'crypto';
+
+const PREFIX = 'PM';
+const GROUP_LENGTH = 4;
+const GROUP_COUNT = 3;
+const LICENSE_PATTERN = /^PM-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+function randomChars(length: number, randomFn: (size: number) => Buffer): string {
+  let output = '';
+  while (output.length < length) {
+    const needed = length - output.length;
+    const buffer = randomFn(needed);
+    for (const byte of buffer) {
+      output += ALPHABET[byte % ALPHABET.length];
+      if (output.length >= length) {
+        break;
+      }
+    }
+  }
+  return output;
+}
+
+export function normalizeLicenseKey(key: string): string {
+  return key.toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+export function calculateLicenseChecksum(input: string): string {
+  const normalized = normalizeLicenseKey(input);
+  if (!normalized) {
+    throw new Error('Cannot calculate checksum for empty input');
+  }
+  const total = normalized.split('').reduce((acc, char, index) => {
+    const position = ALPHABET.indexOf(char);
+    if (position === -1) {
+      throw new Error(`Invalid character ${char} for checksum calculation`);
+    }
+    return acc + (position + 1) * (index + 1);
+  }, 0);
+  return ALPHABET[total % ALPHABET.length];
+}
+
+export function generateLicenseKey(randomFn: (size: number) => Buffer = crypto.randomBytes): string {
+  const bodyLength = GROUP_LENGTH * GROUP_COUNT - 1; // reserve 1 for checksum
+  const body = randomChars(bodyLength, randomFn);
+  const checksum = calculateLicenseChecksum(`${PREFIX}${body}`);
+  const full = `${body}${checksum}`;
+  const groups = [
+    full.slice(0, GROUP_LENGTH),
+    full.slice(GROUP_LENGTH, GROUP_LENGTH * 2),
+    full.slice(GROUP_LENGTH * 2, GROUP_LENGTH * 3),
+  ];
+  return `${PREFIX}-${groups.join('-')}`;
+}
+
+export function isValidLicenseKey(key: string): boolean {
+  if (!key || typeof key !== 'string') {
+    return false;
+  }
+  const upper = key.toUpperCase();
+  if (!LICENSE_PATTERN.test(upper)) {
+    return false;
+  }
+  const normalized = normalizeLicenseKey(upper);
+  if (!normalized.startsWith(PREFIX)) {
+    return false;
+  }
+  const payload = normalized.slice(0, -1);
+  const checksum = normalized.slice(-1);
+  try {
+    const expected = calculateLicenseChecksum(payload);
+    return checksum === expected;
+  } catch {
+    return false;
+  }
+}
+
+export function maskLicenseKey(key: string): string {
+  if (!isValidLicenseKey(key)) {
+    return 'INVALID-KEY';
+  }
+  const upper = key.toUpperCase();
+  const segments = upper.split('-');
+  return `${segments[0]}-XXXX-XXXX-${segments[3]}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "better-sqlite3": "^12.2.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -4831,7 +4832,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4848,6 +4848,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4861,11 +4875,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4965,7 +4987,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5739,7 +5760,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -5755,7 +5775,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5777,6 +5796,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5881,7 +5909,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6343,7 +6370,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6807,6 +6833,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.0.4",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.4.tgz",
@@ -6957,6 +6992,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -7114,6 +7155,12 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -7258,6 +7305,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -7644,7 +7697,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7751,7 +7803,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -9688,7 +9745,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9818,6 +9874,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9856,6 +9918,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
@@ -9893,7 +9961,6 @@
       "version": "3.75.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
       "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -10038,7 +10105,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -10619,6 +10685,32 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10711,7 +10803,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -10777,6 +10868,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -10849,7 +10964,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -11152,7 +11266,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11219,7 +11332,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11295,6 +11407,51 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -11477,7 +11634,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -11784,6 +11940,40 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -12177,6 +12367,18 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -12381,7 +12583,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -12642,7 +12843,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,14 @@
       "electron/preload.cjs"
     ],
     "extraResources": [
-      { "from": "public/logo.ico", "to": "logo.ico" },
-      { "from": "public/logo1.png", "to": "logo1.png" }
+      {
+        "from": "public/logo.ico",
+        "to": "logo.ico"
+      },
+      {
+        "from": "public/logo1.png",
+        "to": "logo1.png"
+      }
     ],
     "win": {
       "icon": "public/logo.ico",
@@ -40,6 +46,7 @@
     }
   },
   "dependencies": {
+    "better-sqlite3": "^12.2.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": [
+    "src",
+    "lib",
+    "api",
+    "db",
+    "electron",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce a SQLite-backed data layer for accounts, licenses, activations, and reallocation logs
- add reusable license key utilities, HMAC helpers, and serverless license handlers with rate limiting
- cover the new flows with unit and integration tests and update the Jest setup to compile API code

## Testing
- npm test -- --watch=false
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc7556afb88324b96e603f2a96e936