### PR TITLE
Add license management client and UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { MatchesTab } from './components/MatchesTab';
 import { StandingsTab } from './components/StandingsTab';
 import { useTournament } from './hooks/useTournament';
 import { RotateCcw } from 'lucide-react';
+import { LicenseManager } from './components/LicenseManager';
 
 function App() {
   const [animationsPaused, setAnimationsPaused] = useState(false);
@@ -155,6 +156,7 @@ function App() {
       </div>
 
       <Header animationsPaused={animationsPaused} onToggleAnimations={toggleAnimations} />
+      <LicenseManager />
       {content}
     </div>
   );

--- a/src/components/LicenseManager.tsx
+++ b/src/components/LicenseManager.tsx
@@ -1,0 +1,255 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  fetchLicenseDetails,
+  submitLicenseCredentials,
+  requestLicenseReset,
+  type LicenseDetails,
+  type LicenseStatus,
+  getHashedDeviceId,
+} from '../services/licenseClient';
+import { LicenseModal } from './LicenseModal';
+
+function maskIdentifier(value?: string): string {
+  if (!value) {
+    return '—';
+  }
+
+  if (value.length <= 12) {
+    return value;
+  }
+
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+function formatLicenseKey(value?: string): string {
+  if (!value) {
+    return '—';
+  }
+
+  return value.replace(/\s+/g, '').toUpperCase();
+}
+
+const STATUS_BADGES: Record<LicenseStatus, string> = {
+  active: 'bg-emerald-500/20 border border-emerald-400 text-emerald-200',
+  invalid: 'bg-red-500/20 border border-red-400 text-red-200',
+  deactivated: 'bg-amber-500/20 border border-amber-400 text-amber-200',
+  unregistered: 'bg-white/10 border border-white/30 text-white/70',
+};
+
+const STATUS_TEXT: Record<LicenseStatus, string> = {
+  active: 'Licence active',
+  invalid: 'Licence invalide',
+  deactivated: 'Licence désactivée',
+  unregistered: 'Aucune licence détectée',
+};
+
+export function LicenseManager() {
+  const [license, setLicense] = useState<LicenseDetails | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [isResetting, setIsResetting] = useState<boolean>(false);
+  const [deviceHash, setDeviceHash] = useState<string>('');
+
+  const loadLicense = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const details = await fetchLicenseDetails();
+      setLicense(details);
+      setDeviceHash(details.deviceHash);
+    } catch (err) {
+      const hashed = await getHashedDeviceId();
+      setLicense({
+        status: 'unregistered',
+        deviceHash: hashed,
+      });
+      setDeviceHash(hashed);
+      setError(err instanceof Error ? err.message : 'Impossible de charger la licence.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadLicense();
+  }, [loadLicense]);
+
+  const currentStatus: LicenseStatus = license?.status ?? 'unregistered';
+
+  const maskedDevice = useMemo(() => maskIdentifier(license?.deviceHash ?? deviceHash), [license, deviceHash]);
+
+  const handleSubmit = useCallback(
+    async (email: string, licenseKey: string) => {
+      setIsSubmitting(true);
+      setActionError(null);
+      setActionMessage(null);
+
+      try {
+        const details = await submitLicenseCredentials(email, licenseKey);
+        setLicense(details);
+        setDeviceHash(details.deviceHash);
+        setActionMessage(details.message ?? 'Licence enregistrée avec succès.');
+        setModalOpen(false);
+      } catch (err) {
+        setActionError(
+          err instanceof Error ? err.message : "Une erreur est survenue lors de l'enregistrement."
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    []
+  );
+
+  const handleReset = useCallback(
+    async (email: string, licenseKey: string) => {
+      if (!email || !licenseKey) {
+        setActionError('Veuillez renseigner votre email et votre clé de licence.');
+        return;
+      }
+
+      setIsResetting(true);
+      setActionError(null);
+      setActionMessage(null);
+
+      try {
+        const message = await requestLicenseReset(email, licenseKey);
+        setActionMessage(message);
+      } catch (err) {
+        setActionError(
+          err instanceof Error ? err.message : 'La demande de réinitialisation a échoué.'
+        );
+      } finally {
+        setIsResetting(false);
+      }
+    },
+    []
+  );
+
+  const handlePanelReset = useCallback(() => {
+    if (!license?.email || !license.licenseKey) {
+      setActionError('Veuillez renseigner vos informations de licence pour demander une réinitialisation.');
+      setModalOpen(true);
+      return;
+    }
+
+    void handleReset(license.email, license.licenseKey);
+  }, [handleReset, license]);
+
+  const handleRefresh = useCallback(() => {
+    void loadLicense();
+  }, [loadLicense]);
+
+  useEffect(() => {
+    if (modalOpen) {
+      setActionError(null);
+      setActionMessage(null);
+    }
+  }, [modalOpen]);
+
+  const statusBadgeClass = STATUS_BADGES[currentStatus];
+  const statusText = STATUS_TEXT[currentStatus];
+
+  return (
+    <section className="mx-6 mt-6">
+      <div className="glass-card border border-white/20 px-6 py-6 shadow-xl">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">Compte &amp; licence</h2>
+            <p className="text-sm text-white/70">
+              Gérez votre clé de licence et l'association de cet appareil.
+            </p>
+            <div className={`mt-3 inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${statusBadgeClass}`}>
+              {loading ? 'Chargement…' : statusText}
+            </div>
+            {!loading && license?.message && (
+              <p className="mt-2 text-xs text-white/60">{license.message}</p>
+            )}
+            {error && (
+              <p className="mt-3 text-sm text-red-200">
+                {error}{' '}
+                <button
+                  type="button"
+                  className="underline decoration-dotted decoration-red-200/70 transition hover:text-red-100"
+                  onClick={handleRefresh}
+                >
+                  Réessayer
+                </button>
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => setModalOpen(true)}
+              className="glass-button rounded-lg px-4 py-2 text-sm font-semibold"
+            >
+              {currentStatus === 'unregistered' ? 'Activer une licence' : 'Mettre à jour la licence'}
+            </button>
+            <button
+              type="button"
+              onClick={handlePanelReset}
+              disabled={isResetting}
+              className="glass-button-secondary rounded-lg px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isResetting ? 'Demande en cours…' : 'Demander réinitialisation'}
+            </button>
+          </div>
+        </div>
+
+        {(actionMessage || actionError) && (
+          <div
+            className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
+              actionMessage
+                ? 'border-emerald-400/70 bg-emerald-500/10 text-emerald-200'
+                : 'border-red-400/70 bg-red-500/10 text-red-200'
+            }`}
+          >
+            {actionMessage ?? actionError}
+          </div>
+        )}
+
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Clé de licence</p>
+            <p className="mt-2 break-all text-lg font-semibold text-white">
+              {loading ? '—' : formatLicenseKey(license?.licenseKey)}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Type de licence</p>
+            <p className="mt-2 text-lg font-semibold text-white">
+              {loading ? '—' : license?.licenseType ?? '—'}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/60">Empreinte appareil</p>
+            <p className="mt-2 text-lg font-semibold text-white">{maskedDevice}</p>
+            <p className="mt-1 text-xs text-white/50">Utilisée pour lier la licence à cet appareil.</p>
+          </div>
+        </div>
+      </div>
+
+      <LicenseModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        status={currentStatus}
+        initialEmail={license?.email}
+        initialLicenseKey={license?.licenseKey}
+        maskedDeviceId={maskedDevice}
+        submitting={isSubmitting}
+        resetInProgress={isResetting}
+        error={actionError}
+        message={actionMessage}
+        onSubmit={handleSubmit}
+        onRequestReset={handleReset}
+      />
+    </section>
+  );
+}

--- a/src/components/LicenseModal.tsx
+++ b/src/components/LicenseModal.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import type { LicenseStatus } from '../services/licenseClient';
+
+interface LicenseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  status?: LicenseStatus;
+  initialEmail?: string;
+  initialLicenseKey?: string;
+  maskedDeviceId?: string;
+  submitting?: boolean;
+  resetInProgress?: boolean;
+  error?: string | null;
+  message?: string | null;
+  onSubmit: (email: string, licenseKey: string) => Promise<void> | void;
+  onRequestReset: (email: string, licenseKey: string) => Promise<void> | void;
+}
+
+const STATUS_LABELS: Record<LicenseStatus, string> = {
+  active: 'Licence active',
+  invalid: 'Licence invalide',
+  deactivated: 'Licence désactivée',
+  unregistered: 'Aucune licence enregistrée',
+};
+
+const STATUS_STYLES: Record<LicenseStatus, string> = {
+  active: 'bg-emerald-500/20 border border-emerald-400 text-emerald-300',
+  invalid: 'bg-red-500/20 border border-red-400 text-red-200',
+  deactivated: 'bg-amber-500/20 border border-amber-400 text-amber-200',
+  unregistered: 'bg-white/10 border border-white/30 text-white/70',
+};
+
+export function LicenseModal({
+  isOpen,
+  onClose,
+  status = 'unregistered',
+  initialEmail = '',
+  initialLicenseKey = '',
+  maskedDeviceId,
+  submitting = false,
+  resetInProgress = false,
+  error,
+  message,
+  onSubmit,
+  onRequestReset,
+}: LicenseModalProps) {
+  const [email, setEmail] = useState(initialEmail);
+  const [licenseKey, setLicenseKey] = useState(initialLicenseKey);
+
+  useEffect(() => {
+    if (isOpen) {
+      setEmail(initialEmail);
+      setLicenseKey(initialLicenseKey);
+    }
+  }, [isOpen, initialEmail, initialLicenseKey]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    await onSubmit(email.trim(), licenseKey.trim());
+  };
+
+  const handleReset = async () => {
+    await onRequestReset(email.trim(), licenseKey.trim());
+  };
+
+  const statusLabel = STATUS_LABELS[status];
+  const statusClass = STATUS_STYLES[status];
+
+  const disableActions = submitting || resetInProgress;
+  const canRequestReset = Boolean(email.trim()) && Boolean(licenseKey.trim());
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
+      <div className="glass-card relative w-full max-w-xl border border-white/20 shadow-2xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 text-white/70 hover:text-white transition-colors"
+          aria-label="Fermer la fenêtre de licence"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        <div className="px-8 py-6">
+          <div className="mb-6">
+            <h2 className="text-2xl font-semibold text-white">Gestion de la licence</h2>
+            <p className="text-sm text-white/70">
+              Activez votre licence ou demandez une réinitialisation pour votre appareil.
+            </p>
+            <div className={`mt-3 inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${statusClass}`}>
+              {statusLabel}
+            </div>
+            {maskedDeviceId && (
+              <p className="mt-2 text-xs text-white/60">
+                Empreinte de l'appareil&nbsp;: <span className="font-semibold text-white">{maskedDeviceId}</span>
+              </p>
+            )}
+          </div>
+
+          {message && (
+            <div className="mb-4 rounded-lg border border-emerald-400/70 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+              {message}
+            </div>
+          )}
+          {error && (
+            <div className="mb-4 rounded-lg border border-red-400/70 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="license-email" className="block text-sm font-medium text-white/80">
+                Adresse email
+              </label>
+              <input
+                id="license-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-white/40 focus:border-white/60 focus:outline-none"
+                placeholder="prenom.nom@example.com"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="license-key" className="block text-sm font-medium text-white/80">
+                Clé de licence
+              </label>
+              <input
+                id="license-key"
+                name="licenseKey"
+                type="text"
+                required
+                value={licenseKey}
+                onChange={(event) => setLicenseKey(event.target.value)}
+                className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-white/40 focus:border-white/60 focus:outline-none"
+                placeholder="XXXX-XXXX-XXXX-XXXX"
+              />
+              <p className="mt-1 text-xs text-white/50">
+                Votre clé reste associée à cet appareil via une empreinte sécurisée.
+              </p>
+            </div>
+
+            <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-between sm:pt-4">
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={disableActions || !canRequestReset}
+                className="glass-button-secondary rounded-lg px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {resetInProgress ? 'Demande en cours…' : 'Demander réinitialisation'}
+              </button>
+
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="glass-button-secondary rounded-lg px-4 py-2 text-sm font-semibold"
+                >
+                  Annuler
+                </button>
+                <button
+                  type="submit"
+                  disabled={disableActions}
+                  className="glass-button rounded-lg px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting ? 'Enregistrement…' : 'Enregistrer la licence'}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/licenseClient.ts
+++ b/src/services/licenseClient.ts
@@ -1,0 +1,356 @@
+const DEVICE_STORAGE_KEY = 'pm.license.deviceId';
+const DEVICE_COOKIE_NAME = 'pm_license_device';
+const DEVICE_SALT = 'petanque-manager::license::v1';
+const API_BASE_URL = '/api/license';
+
+export type LicenseStatus = 'active' | 'invalid' | 'deactivated' | 'unregistered';
+
+export interface LicenseDetails {
+  status: LicenseStatus;
+  email?: string;
+  licenseKey?: string;
+  licenseType?: string;
+  expiresAt?: string;
+  message?: string;
+  deviceHash: string;
+}
+
+interface LicenseApiPayload {
+  status?: string;
+  email?: string;
+  licenseKey?: string;
+  licenseType?: string;
+  expiresAt?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+let cachedDeviceId: string | null = null;
+
+const isBrowser = typeof window !== 'undefined';
+
+function storageAvailable(): boolean {
+  if (!isBrowser) {
+    return false;
+  }
+
+  try {
+    const testKey = '__pm_test__';
+    window.localStorage.setItem(testKey, testKey);
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const canUseLocalStorage = storageAvailable();
+
+function ensureSalted(value: string): string {
+  return value.includes(DEVICE_SALT) ? value : `${value}:${DEVICE_SALT}`;
+}
+
+function readCookie(name: string): string | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  const nameEq = `${name}=`;
+  const decoded = decodeURIComponent(document.cookie ?? '');
+  const parts = decoded.split(';');
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(nameEq)) {
+      return trimmed.substring(nameEq.length) || null;
+    }
+  }
+
+  return null;
+}
+
+function writeCookie(name: string, value: string, days = 365 * 5) {
+  if (!isBrowser) {
+    return;
+  }
+
+  const date = new Date();
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+  const expires = `expires=${date.toUTCString()}`;
+  document.cookie = `${name}=${encodeURIComponent(value)};${expires};path=/;SameSite=Lax`;
+}
+
+function persistDeviceId(deviceId: string) {
+  if (!isBrowser) {
+    return;
+  }
+
+  const salted = ensureSalted(deviceId);
+
+  if (canUseLocalStorage) {
+    window.localStorage.setItem(DEVICE_STORAGE_KEY, salted);
+  }
+
+  writeCookie(DEVICE_COOKIE_NAME, salted);
+  cachedDeviceId = salted;
+}
+
+function readPersistedDeviceId(): string | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  let stored: string | null = null;
+
+  if (canUseLocalStorage) {
+    stored = window.localStorage.getItem(DEVICE_STORAGE_KEY);
+  }
+
+  if (!stored) {
+    stored = readCookie(DEVICE_COOKIE_NAME);
+  }
+
+  return stored ? ensureSalted(stored) : null;
+}
+
+function generateDeviceId(): string {
+  const randomPart = (() => {
+    if (isBrowser && typeof window.crypto !== 'undefined') {
+      if (typeof window.crypto.randomUUID === 'function') {
+        return window.crypto.randomUUID();
+      }
+
+      const buffer = new Uint8Array(16);
+      window.crypto.getRandomValues(buffer);
+      return Array.from(buffer)
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    // Fallback to Math.random if crypto is unavailable (shouldn't happen in production)
+    return `${Math.random().toString(16).slice(2)}${Date.now().toString(16)}`;
+  })();
+
+  return ensureSalted(randomPart);
+}
+
+export function getDeviceId(): string {
+  if (cachedDeviceId) {
+    return cachedDeviceId;
+  }
+
+  const persisted = readPersistedDeviceId();
+
+  if (persisted) {
+    cachedDeviceId = ensureSalted(persisted);
+    // Refresh the persistence to ensure both storage and cookie are in sync
+    persistDeviceId(cachedDeviceId);
+    return cachedDeviceId;
+  }
+
+  const generated = generateDeviceId();
+  persistDeviceId(generated);
+  return generated;
+}
+
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function getHashedDeviceId(): Promise<string> {
+  const id = getDeviceId();
+
+  if (isBrowser && typeof window.crypto !== 'undefined' && window.crypto.subtle) {
+    try {
+      const data = new TextEncoder().encode(id);
+      const digest = await window.crypto.subtle.digest('SHA-256', data);
+      return bufferToHex(digest);
+    } catch (error) {
+      console.warn('Unable to hash device id using SubtleCrypto, falling back to raw id.', error);
+    }
+  }
+
+  // Fallback: return the salted id as-is if hashing fails
+  return id;
+}
+
+async function parseJson<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    console.warn('Unable to parse license API response as JSON.', error);
+    return null;
+  }
+}
+
+function normalizeStatus(status: string | undefined, fallback: LicenseStatus): LicenseStatus {
+  if (typeof status === 'string') {
+    const normalized = status.toLowerCase();
+    if (normalized === 'active' || normalized === 'invalid' || normalized === 'deactivated' || normalized === 'unregistered') {
+      return normalized;
+    }
+  }
+
+  return fallback;
+}
+
+function normalizeLicenseDetails(
+  payload: LicenseApiPayload | null,
+  deviceHash: string,
+  defaults: Partial<LicenseDetails> = {}
+): LicenseDetails {
+  const statusFallback = defaults.status ?? 'unregistered';
+  const normalizedStatus = normalizeStatus(payload?.status, statusFallback);
+
+  return {
+    status: normalizedStatus,
+    email: typeof payload?.email === 'string' ? payload.email : defaults.email,
+    licenseKey: typeof payload?.licenseKey === 'string' ? payload.licenseKey : defaults.licenseKey,
+    licenseType: typeof payload?.licenseType === 'string' ? payload.licenseType : defaults.licenseType,
+    expiresAt: typeof payload?.expiresAt === 'string' ? payload.expiresAt : defaults.expiresAt,
+    message: typeof payload?.message === 'string' ? payload.message : defaults.message,
+    deviceHash,
+  };
+}
+
+function buildHeaders(): HeadersInit {
+  return {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+}
+
+function extractErrorMessage(payload: LicenseApiPayload | null, fallback: string): string {
+  if (payload?.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  return fallback;
+}
+
+export async function fetchLicenseDetails(): Promise<LicenseDetails> {
+  const deviceHash = await getHashedDeviceId();
+
+  try {
+    const response = await fetch(`${API_BASE_URL}?deviceId=${encodeURIComponent(deviceHash)}`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (response.status === 404) {
+      return {
+        status: 'unregistered',
+        deviceHash,
+      };
+    }
+
+    const payload = await parseJson<LicenseApiPayload>(response);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(payload, 'Impossible de récupérer les informations de licence.')
+      );
+    }
+
+    return normalizeLicenseDetails(payload, deviceHash);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error('Impossible de contacter le serveur de licence.');
+  }
+}
+
+export async function submitLicenseCredentials(
+  email: string,
+  licenseKey: string
+): Promise<LicenseDetails> {
+  const trimmedEmail = email.trim();
+  const trimmedKey = licenseKey.trim();
+  const deviceHash = await getHashedDeviceId();
+
+  try {
+    const response = await fetch(API_BASE_URL, {
+      method: 'POST',
+      credentials: 'include',
+      headers: buildHeaders(),
+      body: JSON.stringify({
+        email: trimmedEmail,
+        licenseKey: trimmedKey,
+        deviceId: deviceHash,
+      }),
+    });
+
+    const payload = await parseJson<LicenseApiPayload>(response);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(payload, 'La clé de licence n\'a pas pu être validée.')
+      );
+    }
+
+    return normalizeLicenseDetails(payload, deviceHash, {
+      status: 'invalid',
+      email: trimmedEmail,
+      licenseKey: trimmedKey,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error('Une erreur est survenue lors de l\'enregistrement de la licence.');
+  }
+}
+
+export async function requestLicenseReset(
+  email: string,
+  licenseKey: string
+): Promise<string> {
+  const trimmedEmail = email.trim();
+  const trimmedKey = licenseKey.trim();
+  const deviceHash = await getHashedDeviceId();
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/reset`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: buildHeaders(),
+      body: JSON.stringify({
+        email: trimmedEmail,
+        licenseKey: trimmedKey,
+        deviceId: deviceHash,
+      }),
+    });
+
+    const payload = await parseJson<LicenseApiPayload>(response);
+
+    if (!response.ok) {
+      throw new Error(
+        extractErrorMessage(payload, 'La demande de réinitialisation a échoué.')
+      );
+    }
+
+    return (
+      (typeof payload?.message === 'string' && payload.message) ||
+      'Votre demande de réinitialisation a été envoyée.'
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error('Une erreur est survenue lors de la demande de réinitialisation.');
+  }
+}


### PR DESCRIPTION
## Summary
- add a license client service that persists a salted device identifier, hashes it, and calls the /api/license endpoints
- implement a reusable license modal and a license manager panel in the app shell to handle activation and reset requests
- surface license status, key, type, and masked device fingerprint within the account UI

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc755b5314832496020e3c0a98b818