### PR TITLE
Add hardware hash helper and license API integration

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,78 @@
 // electron/main.cjs
 const { app, BrowserWindow, ipcMain } = require('electron');
+const crypto = require('crypto');
 const path = require('path');
+const si = require('systeminformation');
+
+const APP_SALT = process.env.PM_APP_SALT || 'petanque-manager-license-salt';
+
+let cachedHardwareHash = null;
+
+async function collectHardwareIdentifiers() {
+  const [uuidData, networkInterfaces, biosData, cpuData, diskLayout] = await Promise.all([
+    si.uuid().catch(() => null),
+    si.networkInterfaces().catch(() => []),
+    si.bios().catch(() => ({})),
+    si.cpu().catch(() => ({})),
+    si.diskLayout().catch(() => [])
+  ]);
+
+  const primaryInterface = (networkInterfaces || []).find((iface) => {
+    if (!iface) {
+      return false;
+    }
+    const mac = iface.mac || '';
+    const normalizedMac = mac.replace(/:/g, '').toLowerCase();
+    const invalidMac = !normalizedMac || normalizedMac === '000000000000';
+    return !iface.internal && !iface.virtual && !invalidMac;
+  });
+
+  const volumeIdFromUuid = uuidData?.disk || uuidData?.hardware || uuidData?.os;
+  const volumeIdFromDisk = (diskLayout || []).find((disk) => disk?.serialNum)?.serialNum;
+
+  const identifiers = {
+    volumeId: volumeIdFromDisk || volumeIdFromUuid || '',
+    primaryMac: primaryInterface?.mac || (uuidData?.macs ? uuidData.macs.split(',')[0] : ''),
+    bios: {
+      vendor: biosData?.vendor || '',
+      version: biosData?.version || '',
+      serial: biosData?.serial || '',
+      releaseDate: biosData?.releaseDate || ''
+    },
+    cpu: {
+      manufacturer: cpuData?.manufacturer || '',
+      brand: cpuData?.brand || '',
+      family: cpuData?.family || '',
+      model: cpuData?.model || '',
+      stepping: cpuData?.stepping || '',
+      serial: cpuData?.serial || ''
+    }
+  };
+
+  return identifiers;
+}
+
+function hashHardwareIdentifiers(identifiers) {
+  const normalized = JSON.stringify(identifiers);
+  const salted = `${APP_SALT}::${normalized}`;
+  return crypto.createHash('sha256').update(salted).digest('hex');
+}
+
+async function getHardwareHash() {
+  if (cachedHardwareHash) {
+    return cachedHardwareHash;
+  }
+
+  try {
+    const identifiers = await collectHardwareIdentifiers();
+    const hash = hashHardwareIdentifiers(identifiers);
+    cachedHardwareHash = hash;
+    return hash;
+  } catch (error) {
+    console.error('Failed to generate hardware hash', error);
+    return null;
+  }
+}
 
 function createWindow() {
   // Détermine le chemin de l'app (dev versus prod packagée)
@@ -55,5 +127,10 @@ ipcMain.handle('print-html', async (event, html) => {
   await printWindow.loadURL(
     `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
   );
+});
+
+ipcMain.handle('get-hardware-hash', async () => {
+  const hash = await getHardwareHash();
+  return hash;
 });
 

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -1,3 +1,43 @@
+jest.mock('systeminformation', () => ({
+  uuid: jest.fn(() =>
+    Promise.resolve({
+      disk: 'disk-uuid',
+      hardware: 'hardware-uuid',
+      os: 'os-uuid',
+      macs: 'AA:BB:CC:DD:EE:FF,11:22:33:44:55:66'
+    })
+  ),
+  networkInterfaces: jest.fn(() =>
+    Promise.resolve([
+      { mac: '00:00:00:00:00:00', internal: false, virtual: false },
+      { mac: 'AA:BB:CC:DD:EE:FF', internal: false, virtual: false }
+    ])
+  ),
+  bios: jest.fn(() =>
+    Promise.resolve({
+      vendor: 'ACME',
+      version: '1.2',
+      serial: 'BIOS123',
+      releaseDate: '2024-01-01'
+    })
+  ),
+  cpu: jest.fn(() =>
+    Promise.resolve({
+      manufacturer: 'Intel',
+      brand: 'Core i7',
+      family: 'i7',
+      model: '123',
+      stepping: '1',
+      serial: 'CPU123'
+    })
+  ),
+  diskLayout: jest.fn(() =>
+    Promise.resolve([
+      { serialNum: 'VOLUME123' }
+    ])
+  )
+}));
+
 jest.mock('electron', () => {
   const ipcMain = { handle: jest.fn() };
   const app = {
@@ -23,6 +63,7 @@ jest.mock('electron', () => {
 });
 
 import { ipcMain } from 'electron';
+import { createHash } from 'crypto';
 
 describe('print-html error handling', () => {
   test('sends print-error when printing fails', async () => {
@@ -33,5 +74,39 @@ describe('print-html error handling', () => {
     await handler(mockEvent, '<html></html>');
 
     expect(mockEvent.sender.send).toHaveBeenCalledWith('print-error', 'boom');
+  });
+});
+
+describe('hardware hash generation', () => {
+  test('returns salted SHA-256 hash from system identifiers', async () => {
+    await import('./main.cjs');
+    const handler = ipcMain.handle.mock.calls.find(c => c[0] === 'get-hardware-hash')[1];
+
+    const hash = await handler();
+
+    const expectedIdentifiers = {
+      volumeId: 'VOLUME123',
+      primaryMac: 'AA:BB:CC:DD:EE:FF',
+      bios: {
+        vendor: 'ACME',
+        version: '1.2',
+        serial: 'BIOS123',
+        releaseDate: '2024-01-01'
+      },
+      cpu: {
+        manufacturer: 'Intel',
+        brand: 'Core i7',
+        family: 'i7',
+        model: '123',
+        stepping: '1',
+        serial: 'CPU123'
+      }
+    };
+
+    const expectedHash = createHash('sha256')
+      .update(`petanque-manager-license-salt::${JSON.stringify(expectedIdentifiers)}`)
+      .digest('hex');
+
+    expect(hash).toBe(expectedHash);
   });
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -2,5 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   printHtml: (html) => ipcRenderer.invoke('print-html', html),
-  onPrintError: (callback) => ipcRenderer.on('print-error', (_event, message) => callback(message))
+  onPrintError: (callback) => ipcRenderer.on('print-error', (_event, message) => callback(message)),
+  getHardwareHash: () => ipcRenderer.invoke('get-hardware-hash')
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "systeminformation": "^5.27.10"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -11728,6 +11729,32 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.27.10",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.10.tgz",
+      "integrity": "sha512-jkeOerLSwLZqJrPHCYltlKHu0PisdepIuS4GwjFFtgQUG/5AQPVZekkECuULqdP0cgrrIHW8Nl8J7WQXo5ypEg==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,14 @@
       "electron/preload.cjs"
     ],
     "extraResources": [
-      { "from": "public/logo.ico", "to": "logo.ico" },
-      { "from": "public/logo1.png", "to": "logo1.png" }
+      {
+        "from": "public/logo.ico",
+        "to": "logo.ico"
+      },
+      {
+        "from": "public/logo1.png",
+        "to": "logo1.png"
+      }
     ],
     "win": {
       "icon": "public/logo.ico",
@@ -42,7 +48,8 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "systeminformation": "^5.27.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/utils/licenseApi.ts
+++ b/src/utils/licenseApi.ts
@@ -1,0 +1,97 @@
+const HARDWARE_HASH_STORAGE_KEY = 'petanque-manager.hardware-hash';
+
+let hardwareHashCache: string | null = null;
+
+async function readHardwareHashFromBridge(): Promise<string | null> {
+  if (!window.electronAPI?.getHardwareHash) {
+    return null;
+  }
+
+  const hash = await window.electronAPI.getHardwareHash();
+  return hash ?? null;
+}
+
+async function ensureHardwareHash(): Promise<string> {
+  if (hardwareHashCache) {
+    return hardwareHashCache;
+  }
+
+  const storage = typeof window !== 'undefined' ? window.localStorage : null;
+  const stored = storage?.getItem(HARDWARE_HASH_STORAGE_KEY);
+  if (stored) {
+    hardwareHashCache = stored;
+    return stored;
+  }
+
+  const bridgeHash = await readHardwareHashFromBridge();
+  if (!bridgeHash) {
+    throw new Error('Unable to obtain hardware fingerprint');
+  }
+
+  hardwareHashCache = bridgeHash;
+  storage?.setItem(HARDWARE_HASH_STORAGE_KEY, bridgeHash);
+  return bridgeHash;
+}
+
+async function postLicenseRequest(
+  endpoint: string | undefined,
+  payload: Record<string, unknown>
+) {
+  if (!endpoint) {
+    throw new Error('Missing license endpoint configuration');
+  }
+
+  const hardwareHash = await ensureHardwareHash();
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      ...payload,
+      hardwareHash
+    })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(errorText || 'License request failed');
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return response.json();
+  }
+
+  return response.text();
+}
+
+export async function activateLicense(payload: Record<string, unknown>) {
+  return postLicenseRequest(import.meta.env.VITE_LICENSE_ACTIVATION_URL, payload);
+}
+
+export async function fetchLicenseStatus(payload: Record<string, unknown> = {}) {
+  return postLicenseRequest(import.meta.env.VITE_LICENSE_STATUS_URL, payload);
+}
+
+export async function getStoredHardwareHash() {
+  if (hardwareHashCache) {
+    return hardwareHashCache;
+  }
+
+  const storage = typeof window !== 'undefined' ? window.localStorage : null;
+  const stored = storage?.getItem(HARDWARE_HASH_STORAGE_KEY);
+  if (stored) {
+    hardwareHashCache = stored;
+    return stored;
+  }
+
+  const hash = await readHardwareHashFromBridge();
+  if (hash) {
+    hardwareHashCache = hash;
+    storage?.setItem(HARDWARE_HASH_STORAGE_KEY, hash);
+  }
+
+  return hardwareHashCache;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,8 +3,18 @@
 interface ElectronAPI {
   printHtml: (html: string) => Promise<void>;
   onPrintError: (callback: (message: string) => void) => void;
+  getHardwareHash: () => Promise<string | null>;
 }
 
 interface Window {
   electronAPI?: ElectronAPI;
+}
+
+interface ImportMetaEnv {
+  readonly VITE_LICENSE_ACTIVATION_URL?: string;
+  readonly VITE_LICENSE_STATUS_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
## Summary
- gather BIOS, CPU, disk, and MAC details in the main process, salt them, and return a cached SHA-256 hash
- expose the salted hardware hash through the preload bridge and type declarations, and add renderer utilities that attach the hash to activation/status requests
- add the systeminformation dependency and extend tests to cover the new hardware hash handler

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc755c80288324af3292f7d36af811