### PR TITLE
Implement match differential tie-break in standings

### DIFF
--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -12,7 +12,24 @@ export function StandingsTab({ teams }: StandingsTabProps) {
     if (b.wins !== a.wins) {
       return b.wins - a.wins;
     }
-    return b.performance - a.performance;
+    if (b.performance !== a.performance) {
+      return b.performance - a.performance;
+    }
+
+    const tieBreakA = a.tieBreakDeltas ?? [];
+    const tieBreakB = b.tieBreakDeltas ?? [];
+    const maxLength = Math.max(tieBreakA.length, tieBreakB.length);
+
+    for (let i = 0; i < maxLength; i += 1) {
+      const deltaA = tieBreakA[i] ?? 0;
+      const deltaB = tieBreakB[i] ?? 0;
+
+      if (deltaB !== deltaA) {
+        return deltaB - deltaA;
+      }
+    }
+
+    return 0;
   });
 
   const getPositionIcon = (index: number) => {

--- a/src/components/__tests__/StandingsTab.test.tsx
+++ b/src/components/__tests__/StandingsTab.test.tsx
@@ -1,0 +1,252 @@
+import * as React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StandingsTab } from '../StandingsTab';
+import { computeTeamStats } from '../../hooks/teamStats';
+import { Tournament, Team, Player, Match } from '../../types/tournament';
+
+afterEach(() => {
+  cleanup();
+});
+
+function makePlayer(teamId: string, index: number): Player {
+  return {
+    id: `${teamId}-player-${index}`,
+    name: `${teamId.toUpperCase()} Player ${index}`,
+    label: `${teamId.toUpperCase()}-${index}`,
+    cyberImplants: [],
+    neuralScore: 0,
+    combatRating: 0,
+    hackingLevel: 0,
+    augmentationLevel: 0,
+  };
+}
+
+function makeTeam(id: string): Team {
+  return {
+    id,
+    name: id,
+    players: [makePlayer(id, 1), makePlayer(id, 2)],
+    wins: 0,
+    losses: 0,
+    pointsFor: 0,
+    pointsAgainst: 0,
+    performance: 0,
+    tieBreakDeltas: [],
+    teamRating: 0,
+    synchroLevel: 0,
+  };
+}
+
+function createTournament(teams: Team[], matches: Match[], matchesB: Match[] = []): Tournament {
+  return {
+    id: 'tournament-id',
+    name: 'Test Tournament',
+    type: 'doublette',
+    courts: 4,
+    teams,
+    matches,
+    matchesB,
+    pools: [],
+    currentRound: 0,
+    completed: false,
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    securityLevel: 0,
+    networkStatus: 'online',
+    poolsGenerated: false,
+  };
+}
+
+describe('StandingsTab tie-break sorting', () => {
+  it('orders tied teams using their first tie-break differential', () => {
+    const teams = [
+      makeTeam('alpha'),
+      makeTeam('beta'),
+      makeTeam('gamma'),
+      makeTeam('delta'),
+    ];
+
+    const matches: Match[] = [
+      {
+        id: 'm1',
+        round: 1,
+        court: 1,
+        team1Id: 'alpha',
+        team2Id: 'gamma',
+        team1Score: 13,
+        team2Score: 5,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm2',
+        round: 1,
+        court: 2,
+        team1Id: 'beta',
+        team2Id: 'delta',
+        team1Score: 13,
+        team2Score: 7,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm3',
+        round: 2,
+        court: 1,
+        team1Id: 'alpha',
+        team2Id: 'delta',
+        team1Score: 7,
+        team2Score: 13,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+    ];
+
+    const matchesB: Match[] = [
+      {
+        id: 'm4',
+        round: 2,
+        court: 2,
+        team1Id: 'beta',
+        team2Id: 'gamma',
+        team1Score: 9,
+        team2Score: 13,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+    ];
+
+    const tournament = createTournament(teams, matches, matchesB);
+    const teamsWithStats = computeTeamStats(tournament);
+
+    const alpha = teamsWithStats.find(team => team.id === 'alpha');
+    const beta = teamsWithStats.find(team => team.id === 'beta');
+
+    expect(alpha?.tieBreakDeltas).toEqual([8, -6]);
+    expect(beta?.tieBreakDeltas).toEqual([6, -4]);
+
+    render(<StandingsTab teams={teamsWithStats} />);
+
+    const rows = screen.getAllByRole('row');
+    const dataRows = rows.slice(1);
+
+    expect(dataRows[0]).toHaveTextContent('ALPHA Player 1');
+    expect(dataRows[1]).toHaveTextContent('BETA Player 1');
+  });
+
+  it('breaks remaining ties using later match differentials', () => {
+    const teams = [
+      makeTeam('omega'),
+      makeTeam('sigma'),
+      makeTeam('gamma'),
+      makeTeam('delta'),
+      makeTeam('epsilon'),
+    ];
+
+    const matches: Match[] = [
+      {
+        id: 'm12',
+        round: 2,
+        court: 1,
+        team1Id: 'omega',
+        team2Id: 'delta',
+        team1Score: 10,
+        team2Score: 13,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm10',
+        round: 1,
+        court: 1,
+        team1Id: 'omega',
+        team2Id: 'gamma',
+        team1Score: 13,
+        team2Score: 8,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm14',
+        round: 3,
+        court: 1,
+        team1Id: 'omega',
+        team2Id: 'epsilon',
+        team1Score: 13,
+        team2Score: 11,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm11',
+        round: 1,
+        court: 2,
+        team1Id: 'sigma',
+        team2Id: 'delta',
+        team1Score: 13,
+        team2Score: 8,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm13',
+        round: 2,
+        court: 2,
+        team1Id: 'sigma',
+        team2Id: 'epsilon',
+        team1Score: 11,
+        team2Score: 13,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+      {
+        id: 'm15',
+        round: 3,
+        court: 2,
+        team1Id: 'sigma',
+        team2Id: 'gamma',
+        team1Score: 13,
+        team2Score: 12,
+        completed: true,
+        isBye: false,
+        battleIntensity: 0,
+        hackingAttempts: 0,
+      },
+    ];
+
+    const tournament = createTournament(teams, matches);
+    const teamsWithStats = computeTeamStats(tournament);
+
+    const omega = teamsWithStats.find(team => team.id === 'omega');
+    const sigma = teamsWithStats.find(team => team.id === 'sigma');
+
+    expect(omega?.tieBreakDeltas).toEqual([5, -3, 2]);
+    expect(sigma?.tieBreakDeltas).toEqual([5, -2, 1]);
+
+    render(<StandingsTab teams={teamsWithStats} />);
+
+    const rows = screen.getAllByRole('row');
+    const dataRows = rows.slice(1);
+
+    expect(dataRows[0]).toHaveTextContent('SIGMA Player 1');
+    expect(dataRows[1]).toHaveTextContent('OMEGA Player 1');
+  });
+});

--- a/src/hooks/teamStats.ts
+++ b/src/hooks/teamStats.ts
@@ -1,51 +1,60 @@
 import { Tournament, Match, Team } from '../types/tournament';
 
 export function computeTeamStats(tournament: Tournament, matches?: Match[]): Team[] {
-  const allMatches = matches ?? [...tournament.matches, ...tournament.matchesB];
+  const combinedMatches = matches ?? [...tournament.matches, ...tournament.matchesB];
+  const matchesWithIndex = combinedMatches.map((match, insertionIndex) => ({
+    match,
+    insertionIndex,
+  }));
 
   return tournament.teams.map(team => {
-    const teamMatches = allMatches.filter(
-      match =>
-        match.completed &&
-        (match.team1Id === team.id ||
-          match.team2Id === team.id ||
-          (match.team1Ids && match.team1Ids.includes(team.id)) ||
-          (match.team2Ids && match.team2Ids.includes(team.id)))
+    const teamMatches = matchesWithIndex.filter(({ match }) =>
+      match.completed &&
+      (match.team1Id === team.id ||
+        match.team2Id === team.id ||
+        (match.team1Ids && match.team1Ids.includes(team.id)) ||
+        (match.team2Ids && match.team2Ids.includes(team.id)))
     );
+
+    teamMatches.sort((a, b) => {
+      if (a.match.round !== b.match.round) {
+        return a.match.round - b.match.round;
+      }
+      return a.insertionIndex - b.insertionIndex;
+    });
 
     let wins = 0;
     let losses = 0;
     let pointsFor = 0;
     let pointsAgainst = 0;
+    const tieBreakDeltas: number[] = [];
 
-    teamMatches.forEach(match => {
-      if (match.isBye && (match.team1Id === team.id || match.team2Id === team.id)) {
-        wins += 1;
-        pointsFor += 13;
-        pointsAgainst += 7;
-        return;
-      }
+    teamMatches.forEach(({ match }) => {
       const isTeam1 =
         match.team1Id === team.id || (match.team1Ids && match.team1Ids.includes(team.id));
       const isTeam2 =
         match.team2Id === team.id || (match.team2Ids && match.team2Ids.includes(team.id));
 
-      if (isTeam1) {
-        pointsFor += match.team1Score || 0;
-        pointsAgainst += match.team2Score || 0;
-        if ((match.team1Score || 0) > (match.team2Score || 0)) {
+      if (match.isBye && (isTeam1 || isTeam2)) {
+        wins += 1;
+        pointsFor += 13;
+        pointsAgainst += 7;
+        tieBreakDeltas.push(13 - 7);
+        return;
+      }
+
+      if (isTeam1 || isTeam2) {
+        const teamScore = isTeam1 ? match.team1Score ?? 0 : match.team2Score ?? 0;
+        const opponentScore = isTeam1 ? match.team2Score ?? 0 : match.team1Score ?? 0;
+
+        pointsFor += teamScore;
+        pointsAgainst += opponentScore;
+        if (teamScore > opponentScore) {
           wins += 1;
         } else {
           losses += 1;
         }
-      } else if (isTeam2) {
-        pointsFor += match.team2Score || 0;
-        pointsAgainst += match.team1Score || 0;
-        if ((match.team2Score || 0) > (match.team1Score || 0)) {
-          wins += 1;
-        } else {
-          losses += 1;
-        }
+        tieBreakDeltas.push(teamScore - opponentScore);
       }
     });
 
@@ -56,6 +65,7 @@ export function computeTeamStats(tournament: Tournament, matches?: Match[]): Tea
       pointsFor,
       pointsAgainst,
       performance: pointsFor - pointsAgainst,
+      tieBreakDeltas,
     };
   });
 }

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -30,6 +30,7 @@ export interface Team {
   pointsFor: number;
   pointsAgainst: number;
   performance: number;
+  tieBreakDeltas?: number[];
   teamRating: number;
   synchroLevel: number;
   poolId?: string;


### PR DESCRIPTION
## Summary
- collect chronological match differentials for each team and expose them as tie-break data
- sort the standings by wins, performance, then lexicographic tie-break deltas
- add tests covering tie-break resolution on first and subsequent matches

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cf3cdd34fc8324bb0a49fedc697afe