### PR TITLE
Avoid generating two-team pools for preference three

### DIFF
--- a/src/utils/__tests__/poolGeneration.test.ts
+++ b/src/utils/__tests__/poolGeneration.test.ts
@@ -60,11 +60,18 @@ describe('generatePools', () => {
     expect(sizes).toEqual([3, 3, 4]);
   });
 
-  it('creates a single pool of two when teams modulo three equals two', () => {
+  it('creates pools of four when teams modulo three equals two', () => {
     const teams = makeTeams(8);
     const pools = generatePools(teams, 3);
     const sizes = pools.map(p => p.teamIds.length).sort();
-    expect(sizes).toEqual([2, 3, 3]);
+    expect(sizes).toEqual([4, 4]);
+  });
+
+  it('can create two pools of four to avoid pools of two', () => {
+    const teams = makeTeams(11);
+    const pools = generatePools(teams, 3);
+    const sizes = pools.map(p => p.teamIds.length).sort();
+    expect(sizes).toEqual([3, 4, 4]);
   });
 });
 
@@ -75,7 +82,8 @@ describe('calculateOptimalPools', () => {
   });
 
   it('computes mix for preference three with remainder two', () => {
-    expect(calculateOptimalPools(8, 3)).toEqual({ poolsOf4: 0, poolsOf3: 2, poolsOf2: 1 });
+    expect(calculateOptimalPools(8, 3)).toEqual({ poolsOf4: 2, poolsOf3: 0, poolsOf2: 0 });
+    expect(calculateOptimalPools(11, 3)).toEqual({ poolsOf4: 2, poolsOf3: 1, poolsOf2: 0 });
   });
 
   it('computes mix for preference three with remainder one', () => {

--- a/src/utils/poolGeneration.ts
+++ b/src/utils/poolGeneration.ts
@@ -73,25 +73,21 @@ export function calculateOptimalPools(
       return { poolsOf4: 0, poolsOf3: 0, poolsOf2: 0 };
     }
 
-    let poolsOf3 = Math.floor(totalTeams / 3);
-    let remainder = totalTeams - poolsOf3 * 3;
-    let poolsOf4 = 0;
-    let poolsOf2 = 0;
+    const maxPoolsOf3 = Math.floor(totalTeams / 3);
 
-    if (remainder === 1) {
-      if (poolsOf3 > 0) {
-        poolsOf3 -= 1;
-        poolsOf4 = 1;
-      } else {
-        // Cas limite : 4 équipes
-        poolsOf3 = 0;
-        poolsOf4 = 1;
+    for (let poolsOf3 = maxPoolsOf3; poolsOf3 >= 0; poolsOf3--) {
+      const remainingTeams = totalTeams - poolsOf3 * 3;
+
+      if (remainingTeams === 0) {
+        return { poolsOf4: 0, poolsOf3, poolsOf2: 0 };
       }
-    } else if (remainder === 2) {
-      poolsOf2 = 1;
+
+      if (remainingTeams >= 4 && remainingTeams % 4 === 0) {
+        return { poolsOf4: remainingTeams / 4, poolsOf3, poolsOf2: 0 };
+      }
     }
 
-    return { poolsOf4, poolsOf3, poolsOf2 };
+    return { poolsOf4: 0, poolsOf3: 0, poolsOf2: 0 };
   }
 
   // Préférence pour les poules de 4 (comportement d'origine)


### PR DESCRIPTION
## Summary
- update the pool generation logic so tournaments preferring pools of three now rebalance into pools of four instead of creating groups of two
- extend the pool generation unit tests to cover the new distributions and ensure two-team pools are no longer produced

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e5c6a5ae40832482f1d3a756bdf8f5