### PR TITLE
Add PDF export for tournament standings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
+        "jspdf": "^3.0.3",
+        "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -586,7 +588,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3666,6 +3667,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/plist": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -3684,6 +3691,13 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
@@ -3729,6 +3743,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -4829,6 +4850,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5271,6 +5302,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5634,6 +5685,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5675,6 +5738,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -6072,6 +6145,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.5.0",
@@ -6951,6 +7034,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6980,6 +7074,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -7594,6 +7694,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -7811,6 +7925,12 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -9325,6 +9445,32 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10244,6 +10390,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10381,6 +10533,13 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10871,6 +11030,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -11001,6 +11170,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11137,6 +11313,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -11621,6 +11807,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -11862,6 +12058,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -12150,6 +12356,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -12611,6 +12827,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",
+    "jspdf": "^3.0.3",
+    "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,7 +132,7 @@ function App() {
           />
         )}
         {activeTab === 'standings' && (
-          <StandingsTab teams={tournament.teams} />
+          <StandingsTab tournament={tournament} />
         )}
       </main>
     </>

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -73,14 +73,15 @@ export function MatchesTab({
   const renderTeamLabel = (label: string, options: { italic?: boolean } = {}) => {
     const { italic } = options;
     const textClass = italic ? 'text-white/80 italic' : 'text-white';
+    const parts = label.split(' / ');
     return (
       <div className="flex flex-col items-center gap-1 text-center leading-tight">
-        {label.split(' / ').map((part, index) => (
+        {parts.map((part, index) => (
           <span
             key={`${part}-${index}`}
             className={`font-bold ${textClass}`}
           >
-            {part.trim()}
+            {index < parts.length - 1 ? `${part.trim()} / ` : part.trim()}
           </span>
         ))}
       </div>

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { Team } from '../types/tournament';
-import { Trophy, TrendingUp, TrendingDown, Printer, Loader2 } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Tournament, Team, Match } from '../types/tournament';
+import { Trophy, TrendingUp, TrendingDown, Printer, Loader2, Download } from 'lucide-react';
 
 interface StandingsTabProps {
-  teams: Team[];
+  tournament: Tournament;
 }
 
-export function StandingsTab({ teams }: StandingsTabProps) {
+export function StandingsTab({ tournament }: StandingsTabProps) {
+  const { teams, matches, matchesB, name, type, currentRound, courts } = tournament;
   const isSolo = teams.every(t => t.players.length === 1);
   const sortedTeams = [...teams].sort((a, b) => {
     if (b.wins !== a.wins) {
@@ -46,6 +47,22 @@ export function StandingsTab({ teams }: StandingsTabProps) {
   };
 
   const [isPrinting, setIsPrinting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const teamLookup = useMemo(() => {
+    return teams.reduce<Record<string, { label: string; team: Team }>>((acc, team, index) => {
+      acc[team.id] = {
+        label: `${index + 1}`,
+        team,
+      };
+      return acc;
+    }, {});
+  }, [teams]);
+
+  const formatTournamentType = () => {
+    const formatted = type.charAt(0).toUpperCase() + type.slice(1).replace('-', ' ');
+    return formatted;
+  };
 
   useEffect(() => {
     if (window.electronAPI?.onPrintError) {
@@ -141,6 +158,207 @@ export function StandingsTab({ teams }: StandingsTabProps) {
     }
   };
 
+  const getMatchTeamLabel = (match: Match, teamKey: 'team1' | 'team2') => {
+    if (match.isBye) {
+      return 'Exempt';
+    }
+
+    const teamIds = teamKey === 'team1' ? match.team1Ids : match.team2Ids;
+    const singleTeamId = teamKey === 'team1' ? match.team1Id : match.team2Id;
+
+    if (teamIds && teamIds.length > 0) {
+      return teamIds
+        .map((id) => {
+          const entry = teamLookup[id];
+          if (!entry) {
+            return 'Inconnu';
+          }
+          const playerNames = entry.team.players.map((player) => player.name).join(' / ');
+          return `${entry.label} - ${playerNames || entry.team.name || 'Équipe'}`;
+        })
+        .join('\n');
+    }
+
+    if (!singleTeamId) {
+      return 'Inconnu';
+    }
+
+    const entry = teamLookup[singleTeamId];
+    if (!entry) {
+      return 'Inconnu';
+    }
+
+    const playerNames = entry.team.players.map((player) => player.name).join(' / ');
+    const fallbackName = entry.team.name || `Équipe ${entry.label}`;
+    return `${entry.label} - ${playerNames || fallbackName}`;
+  };
+
+  const sanitizeFileName = (title: string) => {
+    const sanitized = title
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-zA-Z0-9-_\s]/g, '')
+      .trim()
+      .replace(/\s+/g, '-')
+      .toLowerCase();
+    return sanitized || 'tournoi';
+  };
+
+  const handleExportPdf = async () => {
+    setIsExporting(true);
+
+    try {
+      const [{ default: JsPDF }, { default: autoTable }] = await Promise.all([
+        import('jspdf'),
+        import('jspdf-autotable'),
+      ]);
+
+      const doc = new JsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
+      const pageWidth = doc.internal.pageSize.getWidth();
+      const pageHeight = doc.internal.pageSize.getHeight();
+
+      const addSectionTitle = (title: string, y: number) => {
+        doc.setFontSize(16);
+        doc.text(title, 40, y);
+        return y + 12;
+      };
+
+      const ensureSpace = (currentY: number, requiredSpace = 80) => {
+        if (currentY + requiredSpace > pageHeight - 40) {
+          doc.addPage();
+          return 60;
+        }
+        return currentY;
+      };
+
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(20);
+      doc.text('Rapport du tournoi', pageWidth / 2, 50, { align: 'center' });
+
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(14);
+      doc.text(`Nom : ${name}`, 40, 90);
+      doc.text(`Type : ${formatTournamentType()}`, 40, 110);
+      doc.text(`Terrains : ${courts}`, 40, 130);
+      doc.text(`Tour actuel : ${currentRound}`, 40, 150);
+
+      let cursorY = 190;
+
+      // Section équipes
+      cursorY = addSectionTitle('Liste des équipes', cursorY);
+      cursorY = ensureSpace(cursorY, 120);
+      doc.setFontSize(12);
+      autoTable(doc, {
+        startY: cursorY,
+        head: [['#', "Nom de l'équipe", 'Joueurs']],
+        body: teams.map((team, index) => [
+          `${index + 1}`,
+          team.name || `Équipe ${index + 1}`,
+          team.players.map((player) => player.name).join('\n') || '—',
+        ]),
+        styles: { fontSize: 10, cellPadding: 6 },
+        headStyles: { fillColor: [41, 50, 60], textColor: 255 },
+        columnStyles: {
+          0: { halign: 'center', cellWidth: 40 },
+          1: { cellWidth: 200 },
+          2: { cellWidth: 280 },
+        },
+      });
+      cursorY = ((doc as any).lastAutoTable?.finalY || cursorY) + 30;
+
+      // Section matchs
+      const allMatches: Match[] = [...matches, ...matchesB];
+      if (allMatches.length > 0) {
+        cursorY = ensureSpace(cursorY);
+        cursorY = addSectionTitle('Liste des matchs', cursorY);
+        const matchesByRound = allMatches.reduce<Record<number, Match[]>>((acc, match) => {
+          if (!acc[match.round]) {
+            acc[match.round] = [];
+          }
+          acc[match.round].push(match);
+          return acc;
+        }, {});
+
+        const sortedRounds = Object.keys(matchesByRound)
+          .map(Number)
+          .sort((a, b) => a - b);
+
+        sortedRounds.forEach((round, roundIndex) => {
+          const roundMatches = matchesByRound[round];
+          if (!roundMatches || roundMatches.length === 0) {
+            return;
+          }
+
+          cursorY = ensureSpace(cursorY);
+          doc.setFontSize(13);
+          doc.setFont('helvetica', 'bold');
+          doc.text(`Tour ${round}`, 40, cursorY);
+          cursorY += 10;
+
+          doc.setFont('helvetica', 'normal');
+          autoTable(doc, {
+            startY: cursorY,
+            head: [['Terrain', "Équipe 1", 'Score', "Équipe 2"]],
+            body: roundMatches.map((match) => [
+              match.isBye ? '—' : `${match.court}`,
+              getMatchTeamLabel(match, 'team1'),
+              match.completed
+                ? `${match.team1Score ?? 0} - ${match.team2Score ?? 0}`
+                : 'À jouer',
+              getMatchTeamLabel(match, 'team2'),
+            ]),
+            styles: { fontSize: 10, cellPadding: 6, valign: 'middle' },
+            headStyles: { fillColor: [41, 50, 60], textColor: 255 },
+            columnStyles: {
+              0: { halign: 'center', cellWidth: 60 },
+              1: { cellWidth: 200 },
+              2: { halign: 'center', cellWidth: 80 },
+              3: { cellWidth: 200 },
+            },
+            didDrawPage: (data) => {
+              cursorY = data.cursor.y + 20;
+            },
+          });
+
+          cursorY = ((doc as any).lastAutoTable?.finalY || cursorY) + (roundIndex === sortedRounds.length - 1 ? 30 : 20);
+        });
+      }
+
+      // Section classement
+      cursorY = ensureSpace(cursorY);
+      cursorY = addSectionTitle('Classement', cursorY);
+      autoTable(doc, {
+        startY: cursorY,
+        head: [['Position', isSolo ? 'Joueur' : 'Équipe', 'V', 'D', '+', '-', 'Diff.']],
+        body: sortedTeams.map((team, index) => [
+          `${index + 1}`,
+          team.players.map((player) => player.name).join(' - ') || team.name || `Équipe ${index + 1}`,
+          `${team.wins}`,
+          `${team.losses}`,
+          `${team.pointsFor}`,
+          `${team.pointsAgainst}`,
+          `${team.performance > 0 ? '+' : ''}${team.performance}`,
+        ]),
+        styles: { fontSize: 10, cellPadding: 6 },
+        headStyles: { fillColor: [41, 50, 60], textColor: 255 },
+        columnStyles: {
+          0: { halign: 'center', cellWidth: 70 },
+          1: { cellWidth: 220 },
+          2: { halign: 'center', cellWidth: 40 },
+          3: { halign: 'center', cellWidth: 40 },
+          4: { halign: 'center', cellWidth: 40 },
+          5: { halign: 'center', cellWidth: 40 },
+          6: { halign: 'center', cellWidth: 60 },
+        },
+      });
+
+      const fileName = `${sanitizeFileName(name)}-tournoi.pdf`;
+      doc.save(fileName);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   return (
     <div className="p-6">
       <div className="flex justify-between items-center mb-8">
@@ -150,18 +368,32 @@ export function StandingsTab({ teams }: StandingsTabProps) {
             {teams.length} {isSolo ? 'joueur' : 'équipe'}{teams.length > 1 ? 's' : ''} inscrit{teams.length > 1 ? 's' : ''}
           </div>
           {teams.length > 0 && (
-            <button
-              onClick={handlePrint}
-              disabled={isPrinting}
-              className="glass-button-secondary flex items-center space-x-2 px-4 py-2 font-bold tracking-wide hover:scale-105 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isPrinting ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Printer className="w-4 h-4" />
-              )}
-              <span>{isPrinting ? 'Impression…' : 'Imprimer'}</span>
-            </button>
+            <div className="flex items-center space-x-4">
+              <button
+                onClick={handleExportPdf}
+                disabled={isExporting}
+                className="glass-button-secondary flex items-center space-x-2 px-4 py-2 font-bold tracking-wide hover:scale-105 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isExporting ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Download className="w-4 h-4" />
+                )}
+                <span>{isExporting ? 'Export…' : 'Télécharger en PDF'}</span>
+              </button>
+              <button
+                onClick={handlePrint}
+                disabled={isPrinting}
+                className="glass-button-secondary flex items-center space-x-2 px-4 py-2 font-bold tracking-wide hover:scale-105 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isPrinting ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Printer className="w-4 h-4" />
+                )}
+                <span>{isPrinting ? 'Impression…' : 'Imprimer'}</span>
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/__tests__/StandingsTab.test.tsx
+++ b/src/components/__tests__/StandingsTab.test.tsx
@@ -126,6 +126,7 @@ describe('StandingsTab tie-break sorting', () => {
 
     const tournament = createTournament(teams, matches, matchesB);
     const teamsWithStats = computeTeamStats(tournament);
+    const tournamentWithStats = { ...tournament, teams: teamsWithStats };
 
     const alpha = teamsWithStats.find(team => team.id === 'alpha');
     const beta = teamsWithStats.find(team => team.id === 'beta');
@@ -133,7 +134,7 @@ describe('StandingsTab tie-break sorting', () => {
     expect(alpha?.tieBreakDeltas).toEqual([8, -6]);
     expect(beta?.tieBreakDeltas).toEqual([6, -4]);
 
-    render(<StandingsTab teams={teamsWithStats} />);
+    render(<StandingsTab tournament={tournamentWithStats} />);
 
     const rows = screen.getAllByRole('row');
     const dataRows = rows.slice(1);
@@ -234,6 +235,7 @@ describe('StandingsTab tie-break sorting', () => {
 
     const tournament = createTournament(teams, matches);
     const teamsWithStats = computeTeamStats(tournament);
+    const tournamentWithStats = { ...tournament, teams: teamsWithStats };
 
     const omega = teamsWithStats.find(team => team.id === 'omega');
     const sigma = teamsWithStats.find(team => team.id === 'sigma');
@@ -241,7 +243,7 @@ describe('StandingsTab tie-break sorting', () => {
     expect(omega?.tieBreakDeltas).toEqual([5, -3, 2]);
     expect(sigma?.tieBreakDeltas).toEqual([5, -2, 1]);
 
-    render(<StandingsTab teams={teamsWithStats} />);
+    render(<StandingsTab tournament={tournamentWithStats} />);
 
     const rows = screen.getAllByRole('row');
     const dataRows = rows.slice(1);


### PR DESCRIPTION
## Summary
- add PDF generation dependencies and pass the full tournament object into the standings tab
- implement a "Télécharger en PDF" action that builds a full tournament report with teams, matches, and standings
- adjust grouped team rendering and update unit tests to cover the new props

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e6558a14808324a7504a8db2a50bf8