### PR TITLE
Fix melee match tab rendering crash

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -75,7 +75,6 @@ export function MatchesTab({
     const textClass = italic ? 'text-white/80 italic' : 'text-white';
     const parts = label.split(' / ').filter(Boolean);
 
-        codex/adjust-player-name-display-based-on-length-xe5kv1
     const shouldApplyLongNameLayout = parts.length >= 3;
 
     if (!shouldApplyLongNameLayout) {
@@ -90,7 +89,6 @@ export function MatchesTab({
       );
     }
 
-        main
     const getPlayerName = (part: string) => {
       const hyphenIndex = part.lastIndexOf(' - ');
       if (hyphenIndex !== -1) {


### PR DESCRIPTION
## Summary
- remove stray leftover markers from the melee match label renderer that referenced undefined globals and crashed the UI

## Testing
- npm test -- --runTestsByPath src/components/__tests__/MatchesTabMelee.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e66c26edc08324b34d9c8b06ed6c39