### PR TITLE
Display doublette players on one line in match list

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -77,6 +77,21 @@ export function MatchesTab({
 
     const shouldApplyLongNameLayout = parts.length >= 3;
 
+    if (parts.length <= 2) {
+      return (
+        <div className="flex flex-wrap items-center justify-center gap-1 text-center leading-tight">
+          {parts.map((part, index) => (
+            <React.Fragment key={`${part}-${index}`}>
+              <span className={`font-bold ${textClass}`}>{part.trim()}</span>
+              {index < parts.length - 1 && (
+                <span className={`font-bold ${textClass}`}> / </span>
+              )}
+            </React.Fragment>
+          ))}
+        </div>
+      );
+    }
+
     if (!shouldApplyLongNameLayout) {
       return (
         <div className="flex flex-col items-center gap-1 text-center leading-tight">

--- a/src/components/__tests__/MatchesTab.test.tsx
+++ b/src/components/__tests__/MatchesTab.test.tsx
@@ -261,13 +261,19 @@ describe('MatchesTab display', () => {
       />
     );
 
-    expect(
-      container.querySelector('.flex.flex-wrap.items-center.justify-center.gap-1')
-    ).toBeNull();
+    const inlineContainers = container.querySelectorAll(
+      '.flex.flex-wrap.items-center.justify-center.gap-1'
+    );
+    expect(inlineContainers).toHaveLength(2);
 
-    const firstPart = screen.getByText('1 : A - Alex /');
-    const secondPart = screen.getByText(`B - ${longName}`);
-    expect(firstPart.parentElement).toBe(secondPart.parentElement);
+    const firstTeamParts = Array.from(inlineContainers[0].querySelectorAll('span')).map(
+      span => span.textContent
+    );
+    expect(firstTeamParts).toEqual([
+      '1 : A - Alex',
+      ' / ',
+      `B - ${longName}`,
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- adjust the match list renderer to keep tête-à-tête and doublette player names on a single line
- update MatchesTab tests to validate the new inline layout for short rosters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e66e741d4883248aa254c84f6384f9